### PR TITLE
Use tools config / update Design Tool

### DIFF
--- a/changedConfigfiles/boards.local.txt
+++ b/changedConfigfiles/boards.local.txt
@@ -1,0 +1,54 @@
+## Audio
+# Extra menu entries to tune the behaviour of the Audio library
+
+menu.audiorate=Audio sample rate
+teensy41.menu.audiorate.44=44.1kHz
+teensy41.menu.audiorate.44.build.flags.audiorate=44100.0f
+teensy41.menu.audiorate.44.build.flags.audiorateI=44100
+teensy41.menu.audiorate.48=48kHz
+teensy41.menu.audiorate.48.build.flags.audiorate=48000.0f
+teensy41.menu.audiorate.48.build.flags.audiorateI=48000
+teensy41.menu.audiorate.96=96kHz
+teensy41.menu.audiorate.96.build.flags.audiorate=96000.0f
+teensy41.menu.audiorate.96.build.flags.audiorateI=96000
+teensy40.menu.audiorate.44=44.1kHz
+teensy40.menu.audiorate.44.build.flags.audiorate=44100.0f
+teensy41.menu.audiorate.44.build.flags.audiorateI=44100
+teensy40.menu.audiorate.48=48kHz
+teensy40.menu.audiorate.48.build.flags.audiorate=48000.0f
+teensy41.menu.audiorate.48.build.flags.audiorateI=48000
+teensy40.menu.audiorate.96=96kHz
+teensy40.menu.audiorate.96.build.flags.audiorate=96000.0f
+teensy41.menu.audiorate.96.build.flags.audiorateI=96000
+
+menu.audioblocksize=Audio block size
+teensy41.menu.audioblocksize.normal=128 samples (normal)
+teensy41.menu.audioblocksize.normal.build.flags.audioblocksize=128
+teensy41.menu.audioblocksize.16=16 samples
+teensy41.menu.audioblocksize.16.build.flags.audioblocksize=16
+teensy41.menu.audioblocksize.256=256 samples
+teensy41.menu.audioblocksize.256.build.flags.audioblocksize=256
+teensy40.menu.audioblocksize.normal=128 samples (normal)
+teensy40.menu.audioblocksize.normal.build.flags.audioblocksize=128
+teensy40.menu.audioblocksize.16=16 samples
+teensy40.menu.audioblocksize.16.build.flags.audioblocksize=16
+teensy40.menu.audioblocksize.256=256 samples
+teensy40.menu.audioblocksize.256.build.flags.audioblocksize=256
+
+menu.USBchannelcount=USB channels
+teensy41.menu.USBchannelcount.2=2
+teensy41.menu.USBchannelcount.2.build.flags.USBchannelcount=2
+teensy41.menu.USBchannelcount.4=4
+teensy41.menu.USBchannelcount.4.build.flags.USBchannelcount=4
+teensy41.menu.USBchannelcount.6=6
+teensy41.menu.USBchannelcount.6.build.flags.USBchannelcount=6
+teensy41.menu.USBchannelcount.8=8
+teensy41.menu.USBchannelcount.8.build.flags.USBchannelcount=8
+teensy40.menu.USBchannelcount.2=2
+teensy40.menu.USBchannelcount.2.build.flags.USBchannelcount=2
+teensy40.menu.USBchannelcount.4=4
+teensy40.menu.USBchannelcount.4.build.flags.USBchannelcount=4
+teensy40.menu.USBchannelcount.6=6
+teensy40.menu.USBchannelcount.6.build.flags.USBchannelcount=6
+teensy40.menu.USBchannelcount.8=8
+teensy40.menu.USBchannelcount.8.build.flags.USBchannelcount=8

--- a/changedConfigfiles/platform.txt
+++ b/changedConfigfiles/platform.txt
@@ -1,0 +1,137 @@
+# https://www.pjrc.com/teensy/td_download.html
+# https://arduino.github.io/arduino-cli/latest/platform-specification/
+# https://arduino.github.io/arduino-cli/0.30/platform-specification/
+
+name=Teensyduino
+version=1.8.5
+rewriting=disabled
+
+# Teensyduino Installer
+compiler.path={runtime.hardware.path}/../tools/
+teensytools.path={runtime.hardware.path}/../tools/
+
+# Arduino Boards Manager
+#compiler.path={runtime.tools.teensy-compile.path}/
+#teensytools.path={runtime.tools.teensy-tools.path}/
+
+build.flags.audioblocksize=128
+build.flags.audiorate=44100.0f
+build.flags.audiorateI=44100
+build.flags.USBchannelcount=2
+
+build.flags.audio=-DAUDIO_BLOCK_SAMPLES={build.flags.audioblocksize} -DAUDIO_SAMPLE_RATE_EXACT={build.flags.audiorate} -DAUDIO_SAMPLE_RATE_I={build.flags.audiorateI} -DAUDIO_USB_CHANNEL_COUNT={build.flags.USBchannelcount}
+
+## Debugger - Experimental
+#debug.executable={build.path}/{build.project_name}.elf
+#debug.toolchain=gcc
+#debug.toolchain.path={compiler.path}{build.toolchain}
+#debug.toolchain.prefix=arm-none-eabi-
+#debug.server=openocd
+#debug.server.openocd.path={teensytools.path}tdebug
+#debug.server.openocd.scripts_dir=unused
+#debug.server.openocd.script=toolspath:{teensytools.path}:buildpath:{build.path}:name:{build.project_name}:board:{build.board}
+
+## EEPROM Data
+compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0
+compiler.elf2hex.flags=-O ihex -R .eeprom
+
+## Preprocessor Includes
+recipe.preproc.includes="{compiler.path}{build.toolchain}{build.command.g++}" -M -MG -MP -x c++ -w {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}"
+
+## Preprocessor Macros
+recipe.preproc.macros="{compiler.path}{build.toolchain}{build.command.g++}" -E -CC -x c++ -w {compiler.cpp.flags} {build.flags.common} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}" -o "{preprocessed_file_path}"
+
+## New Preprocessor for Arduino 1.9
+tools.arduino-preprocessor.path={runtime.tools.arduino-preprocessor.path}
+tools.arduino-preprocessor.cmd.path={path}/arduino-preprocessor
+tools.arduino-preprocessor.pattern="{cmd.path}" "{source_file}" "{codecomplete}" -- -std=gnu++14
+
+## Precompile Arduino.h header
+recipe.hooks.sketch.prebuild.1.pattern="{teensytools.path}precompile_helper" "{runtime.platform.path}/cores/{build.core}" "{build.path}" "{compiler.path}{build.toolchain}{build.command.g++}" -x c++-header {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{runtime.platform.path}/cores/{build.core}" "{build.path}/pch/Arduino.h" -o "{build.path}/pch/Arduino.h.gch"
+
+## Compile c++ files
+recipe.cpp.o.pattern="{compiler.path}{build.toolchain}{build.command.g++}" -c {build.flags.audio} {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.cpp} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} "-I{build.path}/pch" {includes} "{source_file}" -o "{object_file}"
+
+## Compile c files
+recipe.c.o.pattern="{compiler.path}{build.toolchain}{build.command.gcc}" -c {build.flags.audio} {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.c} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}" -o "{object_file}"
+
+## Compile S files
+recipe.S.o.pattern="{compiler.path}{build.toolchain}{build.command.gcc}" -c {build.flags.audio} {build.flags.optimize} {build.flags.common} {build.flags.dep} {build.flags.S} {build.flags.cpu} {build.flags.defs} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DF_CPU={build.fcpu} -D{build.usbtype} -DLAYOUT_{build.keylayout} {includes} "{source_file}" -o "{object_file}"
+
+## Create archives
+recipe.ar.pattern="{compiler.path}{build.toolchain}{build.command.ar}" rcs "{archive_file_path}" "{object_file}"
+
+## Link
+recipe.c.combine.pattern="{compiler.path}{build.toolchain}{build.command.linker}" {build.flags.optimize} {build.flags.ld} {build.flags.ldspecs} {build.flags.cpu} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" {build.flags.libs}
+
+## Patch ELF - TODO: not supported by modern Arduino...  :(
+recipe.elfpatch.pattern="{teensytools.path}/{build.elfpatch}" -mmcu={build.mcu} "{build.path}/{build.project_name}.elf" "{sketch_path}/disk"
+
+## Create eeprom
+recipe.objcopy.eep.pattern="{compiler.path}{build.toolchain}{build.command.objcopy}" {compiler.objcopy.eep.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"
+
+## Create hex
+recipe.objcopy.hex.pattern="{compiler.path}{build.toolchain}{build.command.objcopy}" {compiler.elf2hex.flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
+
+## EHEX file - for Teensy 4.x secure mode
+recipe.hooks.objcopy.postobjcopy.1.pattern="{teensytools.path}teensy_secure" encrypthex {build.board} "{build.path}/{build.project_name}.hex"
+
+
+## Post Build - inform Teensy Loader of new file
+recipe.hooks.postbuild.1.pattern="{teensytools.path}teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={teensytools.path}" "-board={build.board}"
+recipe.hooks.postbuild.2.pattern="{teensytools.path}stdout_redirect" "{build.path}/{build.project_name}.sym" "{compiler.path}{build.toolchain}{build.command.objdump}" -t -C "{build.path}/{build.project_name}.elf"
+recipe.hooks.postbuild.3.pattern="{teensytools.path}teensy_size" "{build.path}/{build.project_name}.elf"
+#
+# objdump to create .lst file is VERY SLOW for huge files
+# https://forum.pjrc.com/threads/68121?p=288306&viewfull=1#post288306
+#
+recipe.hooks.postbuild.4.pattern="{teensytools.path}stdout_redirect" "{build.path}/{build.project_name}.lst" "{compiler.path}{build.toolchain}{build.command.objdump}" -d -S -C "{build.path}/{build.project_name}.elf"
+
+
+## Compute size
+recipe.size.pattern="{compiler.path}{build.toolchain}{build.command.size}" -A "{build.path}/{build.project_name}.elf"
+recipe.size.regex=^(?:\.text|\.text\.progmem|\.text\.itcm|\.data|\.text\.csf)\s+([0-9]+).*
+recipe.size.regex.data=^(?:\.usbdescriptortable|\.dmabuffers|\.usbbuffers|\.data|\.bss|\.noinit|\.text\.itcm|\.text\.itcm\.padding)\s+([0-9]+).*
+recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
+
+## Teensy Ports Discovery
+##  Arduino 1.8.9 requires pathPrefs patch
+##  discovery patters have only limited support for substitution macros,
+##  so we can not use {teensytools.path} or {compiler.path} here
+
+# Teensyduino Installer
+discovery.teensy.pattern="{runtime.hardware.path}/../tools/teensy_ports" -J2
+
+# Arduino Boards Manager
+#discovery.teensy.pattern="{runtime.tools.teensy-tools.path}/teensy_ports" -J2
+#pluggable_discovery.required=teensy:teensy-discovery
+#pluggable_monitor.required.teensy=teensy:teensy-monitor
+
+
+## Teensy Loader
+
+# Teensyduino Installer
+tools.teensyloader.cmd.path={runtime.hardware.path}/../tools
+
+# Arduino Boards Manager
+#tools.teensyloader.cmd.path={runtime.tools.teensy-tools.path}
+
+tools.teensyloader.upload.params.quiet=
+tools.teensyloader.upload.params.verbose=-verbose
+tools.teensyloader.upload.pattern="{cmd.path}/teensy_post_compile" "-file={build.project_name}" "-path={build.path}" "-tools={cmd.path}" "-board={build.board}" -reboot "-port={serial.port}" "-portlabel={serial.port.label}" "-portprotocol={serial.port.protocol}"
+
+
+
+
+## Export hex
+recipe.output.tmp_file={build.project_name}.hex
+recipe.output.save_file={build.project_name}.{build.board}.hex
+recipe.hooks.savehex.postsavehex.1.pattern="{teensytools.path}teensy_secure" encrypthex {build.board} "{sketch_path}/{build.project_name}.{build.board}.hex"
+
+# TODO: missing patch in 1.6.6...
+recipe.output.tmp_file2={build.project_name}.elf
+recipe.output.save_file2={build.project_name}.elf
+
+
+# documentation on this file's format
+# https://arduino.github.io/arduino-cli/latest/platform-specification/

--- a/changedCorefiles/usb_audio.h
+++ b/changedCorefiles/usb_audio.h
@@ -79,8 +79,9 @@ public:
 		bool receivingData;
 	};
 
-	AudioInputUSB(float kp =400.f,float ki =.2f ) :
-	AudioStream(0, NULL), _kp(kp), _ki(ki) { begin(); }
+	AudioInputUSB(float kp =400.f,float ki =.2f ) 
+		: AudioStream(0, NULL), _kp(kp), _ki(ki) 
+		{ begin(); }
 	virtual void update(void);
 	void begin(void);
 	float getBufferedSamples() const;
@@ -111,6 +112,17 @@ private:
 	static void releaseBlocks(uint16_t bufferIdx);
 };
 
+#if USB_AUDIO_NO_CHANNELS_480 >= 4
+class AudioInputUSBQuad : public AudioInputUSB { public: AudioInputUSBQuad(float kp =400.f,float ki =.2f) : AudioInputUSB(kp, ki) {} };
+#if USB_AUDIO_NO_CHANNELS_480 >= 6
+class AudioInputUSBHex : public AudioInputUSB { public: AudioInputUSBHex(float kp =400.f,float ki =.2f) : AudioInputUSB(kp, ki) {} };
+#if USB_AUDIO_NO_CHANNELS_480 >= 8
+class AudioInputUSBOct : public AudioInputUSB { public: AudioInputUSBOct(float kp =400.f,float ki =.2f) : AudioInputUSB(kp, ki) {} };
+#endif // USB_AUDIO_NO_CHANNELS_480 >= 8
+#endif // USB_AUDIO_NO_CHANNELS_480 >= 6
+#endif // USB_AUDIO_NO_CHANNELS_480 >= 4
+
+
 #define TARGET_TX_BUFFER_TIME_S 0.0035f	//targeted buffered time (latency) in seconds
 class AudioOutputUSB : public AudioStream
 {
@@ -129,6 +141,7 @@ public:
 		bool transmittingData;
 	};
 	AudioOutputUSB(void) : AudioStream(USB_AUDIO_MAX_NO_CHANNELS, inputQueueArray) { begin(); }
+	AudioOutputUSB(int nch) : AudioStream(nch, inputQueueArray) { begin(); }
 	virtual void update(void);
 	void begin(void);
 	friend unsigned int usb_audio_transmit_callback(void);
@@ -146,6 +159,17 @@ private:
 	static uint16_t outgoing_count;
 	audio_block_t *inputQueueArray[USB_AUDIO_MAX_NO_CHANNELS];
 };
+
+#if USB_AUDIO_NO_CHANNELS_480 >= 4
+class AudioOutputUSBQuad : public AudioOutputUSB { public: AudioOutputUSBQuad(void) : AudioOutputUSB(4) {} };
+#if USB_AUDIO_NO_CHANNELS_480 >= 6
+class AudioOutputUSBHex : public AudioOutputUSB { public: AudioOutputUSBHex(void) : AudioOutputUSB(6) {} };
+#if USB_AUDIO_NO_CHANNELS_480 >= 8
+class AudioOutputUSBOct : public AudioOutputUSB { public: AudioOutputUSBOct(void) : AudioOutputUSB(8) {} };
+#endif // USB_AUDIO_NO_CHANNELS_480 >= 8
+#endif // USB_AUDIO_NO_CHANNELS_480 >= 6
+#endif // USB_AUDIO_NO_CHANNELS_480 >= 4
+
 #endif // __cplusplus
 
 #endif // AUDIO_INTERFACE

--- a/changedGUI/index.html
+++ b/changedGUI/index.html
@@ -1,0 +1,5783 @@
+<!DOCTYPE html>
+<!-- vim: set ts=4: -->
+<html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+
+<!--
+  Modified from original Node-Red source, for audio system visualization
+
+  Copyright 2013 IBM Corp.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<head>
+<title>Audio System Design Tool for Teensy Audio Library</title>
+<link href="bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
+<link href="jquery/css/smoothness/jquery-ui-1.10.3.custom.min.css" rel="stylesheet" media="screen">
+<link rel="stylesheet" type="text/css" href="orion/built-editor.css"/>
+<link rel="stylesheet" type="text/css" href="font-awesome/css/font-awesome.min.css"/>
+<link rel="stylesheet" href="style.css">
+<style>
+table.doc {border-spacing:3px; border-collapse:separate; font-size: 80%}
+tr.top {background-color:#C0C0C0}
+tr.odd {background-color:#F0F0F0}
+tr.even {background-color:#E0E0E0}
+p.func {padding-bottom:0; margin:0px}
+p.desc {padding-left:2em; margin:0px; padding-top:0.2em; padding-bottom:0.8em; font-size:0.75em}
+p.exam {padding-left:2em; text-indent:-1.2em; margin:0px; padding-top:0; padding-bottom:0.5em; font-size:0.75em; font-weight:bold}
+pre.desc {padding-left:3em; margin:0px; padding-top:0em; padding-bottom:0.8em; font-size:0.75em;
+	background-color:#FFFFFF; border:0px; line-height:100%;
+}
+span.indent {padding-left:2em}
+span.literal {color: #006699}
+span.comment {color: #777755}
+span.keyword {color: #cc6600}
+span.function {color: #996600}
+span.mainfunction {color: #993300; font-weight: bolder}
+</style>
+</head>
+<body spellcheck="false">
+<div class="navbar navbar-inverse navbar-fixed-top">
+	<div class="navbar-inner">
+		<div class="container-fluid">
+			<span class="brand">Audio System Design Tool for <a href="http://www.pjrc.com/teensy/td_libs_Audio.html" target="_blank">Teensy Audio Library</a></span>
+			<div class="btn-group pull-right">
+				<a class="btn dropdown-toggle" data-toggle="dropdown" href="#"><i class="icon-align-justify"></i> <span class="caret"></span></a>
+				<ul class="dropdown-menu">
+					<li><a id="btn-sidebar" tabindex="-1" href="#"><i class="icon-ok pull-right"></i><i class="icon-list-alt"></i> Sidebar</a></li>
+					<li class="divider"></li>
+					<!-- <li><a id="btn-node-status" tabindex="-1" href="#"><i class="icon-ok pull-right"></i><i class="icon-info-sign"></i> Node Status</a></li>
+					<li class="divider"></li>
+-->
+					<!--
+<li class="dropdown-submenu pull-left"><a tabindex="-1" href="#"><i class="icon-edit"></i> Import from...</a>
+						<ul class="dropdown-menu">
+							<li><a id="btn-import" tabindex="-1" href="#"><i class="icon-edit"></i> Clipboard...</a></li>
+							<li id="flow-menu-parent" class="dropdown-submenu pull-left">
+								<a tabindex="-1" href="#"><i class="icon-book"></i> Library</a>
+								<ul class="dropdown-menu"></ul>
+							</li>
+						</ul>
+					</li>
+					<li id="li-menu-export" class="dropdown-submenu disabled pull-left"><a tabindex="-1" href="#"><i class="icon-share"></i> Export to...</a>
+						<ul class="dropdown-menu">
+							<li id="li-menu-export-clipboard" class="disabled"><a id="btn-export-clipboard" tabindex="-1" href="#"><i class="icon-share"></i> Clipboard...</a></li>
+							<li id="li-menu-export-library" class="disabled"><a id="btn-export-library" tabindex="-1" href="#"><i class="icon-book"></i> Library...</a></li>
+						</ul>
+					</li>
+					<li class="divider"></li>
+-->
+					<!--
+ <li><a id="btn-config-nodes" tabindex="-1" href="#"><i class="icon-th-list"></i> Configuration nodes...</a></li>
+					<li class="divider"></li>
+-->
+					<!--
+<li class="dropdown-submenu pull-left"><a tabindex="-1" href="#"><i class="icon-th-large"></i> Workspaces</a>
+						<ul id="workspace-menu-list" class="dropdown-menu">
+							<li><a id="btn-workspace-add" tabindex="-1" href="#"><i class="icon-plus"></i> Add</a></li>
+							<li><a id="btn-workspace-edit" tabindex="-1" href="#"><i class="icon-edit"></i> Rename</a></li>
+							<li><a id="btn-workspace-delete" tabindex="-1" href="#"><i class="icon-minus"></i> Delete</a></li>
+							<li class="divider"></li>
+						</ul>
+					</li>
+					<li class="divider"></li>-->
+					<li><a id="btn-keyboard-shortcuts" tabindex="-1" href="#"><i class="icon-question-sign"></i> Keyboard Shortcuts</a></li>
+					<li><a id="btn-help" tabindex="-1" href="http://node-red.github.io/docs" target="_blank"><i class="icon-question-sign"></i> Help...</a></li>
+				</ul>
+			</div>
+			<div class="btn-group pull-left">
+				<a id="btn-deploy" class="btn action-deploy disabled" href="#"><i id="btn-icn-deploy" class="icon-upload"></i>Export</a>
+				<a id="btn-import" class="btn action-import disabled" href="#"><i id="btn-icn-download" class="icon-download"></i>Import</a>
+			</div>
+		</div>
+	</div>
+</div>
+<div id="main-container" class="sidebar-closed">
+	<div id="palette">
+		<img src="img/spin.svg" class="palette-spinner"/>
+		<div id="palette-container" class="palette-scroll">
+		</div>
+		<div id="palette-search">
+			<i class="icon-search"></i><input id="palette-search-input" type="text" placeholder="filter"><a href="#" id="palette-search-clear"><i class="icon-remove"></i></a></input>
+		</div>
+	</div><!-- /palette -->
+
+	<div id="workspace">
+		<ul id="workspace-tabs"></ul>
+		<!--<div id="workspace-add-tab"><a id="btn-workspace-add-tab" href="#"><i class="icon-plus"></i></a></div>-->
+		<div id="chart"></div>
+		<div id="workspace-toolbar">
+			<div class="btn-group">
+				<a class="btn btn-small" href="#"><i class="icon-zoom-out"></i></a>
+				<a class="btn btn-small" href="#"><i class="icon-th"></i></a>
+				<a class="btn btn-small" href="#"><i class="icon-zoom-in"></i></a>
+			</div>
+		</div>
+	</div>
+
+	<div id="chart-zoom-controls">
+		<div class="btn-group">
+			<a class="btn btn-mini" id="btn-zoom-out" href="#"><i class="icon-zoom-out"></i></a>
+			<a class="btn btn-mini" id="btn-zoom-zero" href="#"><i class="icon-th"></i></a>
+			<a class="btn btn-mini" id="btn-zoom-in" href="#"><i class="icon-zoom-in"></i></a>
+		</div>
+	</div>
+
+	<div id="sidebar">
+		<ul id="sidebar-tabs"></ul>
+		<div id="sidebar-content"></div>
+	</div>
+
+	<div id="sidebar-separator"></div>
+
+</div>
+
+<div id="notifications"></div>
+<div id="dropTarget"><div>Drop the flow here</div></div>
+
+<div id="dialog" class="hide"><form id="dialog-form" class="form-horizontal"></form></div>
+<div id="node-config-dialog" class="hide"><form id="dialog-config-form" class="form-horizontal"></form><div class="form-tips" id="node-config-dialog-user-count"></div></div>
+
+<div id="node-dialog-confirm-deploy" class="hide">
+	<form class="form-horizontal">
+		<div id="node-dialog-confirm-deploy-config" style="text-align: center; padding-top: 30px;">
+			Some of the nodes are not properly configured. Are you sure you want to deploy?
+		</div>
+		<div id="node-dialog-confirm-deploy-unknown" style="text-align: center; padding-top: 10px;">
+			The workspace contains some unknown node types:
+			<ul style="width: 300px; margin: auto; text-align: left;" id="node-dialog-confirm-deploy-unknown-list"></ul>
+			Are you sure you want to deploy?
+		</div>
+	</form>
+</div>
+
+<div id="node-dialog-error-deploy" class="hide">
+	<form class="form-horizontal">
+		<div id="node-dialog-error-deploy-noio" style="text-align: center; padding-top: 10px;">
+			<p>The workspace contains no input/output nodes!</p>
+			<p>You need an input or an output to export the data!</p>
+			<p>Without such a input/output function the exported
+			code will not run properly!</p>
+		</div>
+	</form>
+</div>
+
+<div id="node-help" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="node-help-label" aria-hidden="true">
+  <div class="modal-header">
+	<h5 id="node-help-label">Keyboard Shortcuts <span style="float: right;"><a href="http://node-red.github.io/docs" target="_blank">Open help in new window &raquo;</a></span></h5>
+  </div>
+  <div class="modal-body">
+	<table>
+		<tr>
+		  <td><span class="help-key">?</span></td><td>Help</td>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">a</span></td><td>Select all nodes</td>
+		</tr>
+		<tr>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">Space</span></td><td>Toggle sidebar</td>
+		  <td><span class="help-key">Shift</span> <span class="help-key">Click</span></td><td>Select all connected nodes</td>
+		</tr>
+		<tr>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">z</span></td><td>Undo</td>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">Click</span></td><td>Add/remove node from selection</td>
+		</tr>
+		<tr>
+		  <td></td><td></td>
+		  <td><span class="help-key">Delete</span></td><td>Delete selected nodes or link</td>
+		</tr>
+		<tr>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">x</span></td><td>Cut selected nodes</td>
+		  <td></td><td></td>
+		</tr>
+		<tr>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">c</span></td><td>Copy selected nodes</td>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">v</span></td><td>Paste nodes</td>
+		</tr>
+		<tr>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">i</span></td><td>Import nodes</td>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">e</span></td><td>Export selected nodes</td>
+		</tr>
+		<tr>
+		  <td colspan="2"></td>
+		</tr>
+		<tr>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">+</span></td><td>Zoom in</td>
+		  <td><span class="help-key">Ctrl</span> <span class="help-key">-</span></td><td>Zoom out</td>
+		</tr>
+	</table>
+  </div>
+  <div class="modal-footer">
+	<button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+  </div>
+</div>
+
+<div id="node-dialog-library-save-confirm" class="hide">
+	<form class="form-horizontal">
+		<div style="text-align: center; padding-top: 30px;">
+		 A <span id="node-dialog-library-save-type"></span> called <span id="node-dialog-library-save-name"></span> already exists. Overwrite?
+		</div>
+	</form>
+</div>
+
+<div id="node-dialog-library-save" class="hide">
+	<form class="form-horizontal">
+		<div class="form-row">
+			<label for="node-dialog-library-save-folder"><i class="icon-folder-open"></i> Folder</label>
+			<input type="text" id="node-dialog-library-save-folder" placeholder="Folder">
+		</div>
+		<div class="form-row">
+			<label for="node-dialog-library-save-filename"><i class="icon-file"></i> Filename</label>
+			<input type="text" id="node-dialog-library-save-filename" placeholder="Filename">
+		</div>
+	</form>
+</div>
+
+<div id="node-dialog-library-lookup" class="hide">
+	<form class="form-horizontal">
+		<div class="form-row">
+			<ul id="node-dialog-library-breadcrumbs" class="breadcrumb">
+				<li class="active"><a href="#">Library</a></li>
+			</ul>
+		</div>
+		<div class="form-row">
+			<div style="vertical-align: top; display: inline-block; height: 100%; width: 30%; padding-right: 20px;">
+				<div id="node-select-library" style="border: 1px solid #999; width: 100%; height: 100%; overflow:scroll;"><ul></ul></div>
+			</div>
+			<div style="vertical-align: top; display: inline-block;width: 65%; height: 100%;">
+				<div style="height: 100%; width: 95%;" class="node-text-editor" id="node-select-library-text" ></div>
+			</div>
+		</div>
+	</form>
+</div>
+<div id="node-dialog-rename-workspace" class="hide">
+	<form class="form-horizontal">
+		<div class="form-row">
+			<label for="node-input-workspace-name" ><i class="icon-tag"></i> Name:</label>
+			<input type="text" id="node-input-workspace-name">
+		</div>
+	</form>
+</div>
+<div id="node-dialog-delete-workspace" class="hide">
+	<form class="form-horizontal">
+		<div style="text-align: center; padding-top: 30px;">
+		 Are you sure you want to delete '<span id="node-dialog-delete-workspace-name"></span>'?
+		</div>
+	</form>
+</div>
+
+<script type="text/x-red" data-template-name="export-clipboard-dialog">
+	<div class="form-row">
+		<label for="node-input-export" style="display: block; width:100%;"><i class="icon-share"></i> Source Code:</label>
+		<textarea readonly style="font-family: monospace; font-size: 12px; background:rgb(226, 229, 255); padding-left: 0.5em;" class="input-block-level" id="node-input-export" rows="12"></textarea>
+	</div>
+	<div class="form-tips">
+		Select the text above and copy to the clipboard with Ctrl-A Ctrl-C.
+	</div>
+</script>
+<script type="text/x-red" data-template-name="export-library-dialog">
+	<div class="form-row">
+		<label for="node-input-filename" ><i class="icon-tag"></i> Filename:</label>
+		<input type="text" id="node-input-filename" placeholder="Filename">
+	</div>
+</script>
+<script type="text/x-red" data-template-name="import-dialog">
+	<div class="form-row">
+		<label for="node-input-import"><i class="icon-share"></i>Nodes:</label>
+		<textarea style="font-family: monospace; font-size: 12px; background:rgb(226, 229, 255); padding-left: 0.5em;" class="input-block-level" id="node-input-import" rows="5" placeholder="Paste nodes here, or lookup in the library. When importing Arduino code, the whole flow will be replaced."></textarea>
+	</div>
+	<div class="form-tips">
+		<label for="node-input-arduino" style="font-size: 13px; padding: 2px 0px 0px 4px;">
+			<input style="margin-bottom: 4px; margin-right: 4px;" type="checkbox" id="node-input-arduino" checked="checked" class="input-block-level" />
+				&nbsp;Import copied code from the Arduino IDE
+		</label>
+	</div>
+</script>
+
+<script src="jquery/js/jquery-1.9.1.js"></script>
+<script src="bootstrap/js/bootstrap.min.js"></script>
+<script src="jquery/js/jquery-ui-1.10.3.custom.min.js"></script>
+<script src="jquery/js/jquery.ui.touch-punch.min.js"></script>
+<script src="orion/built-editor.min.js"></script>
+<script src="red/d3/d3.v3.min.js"></script>
+<script src="red/main.js"></script>
+<script src="red/ui/state.js"></script>
+<script src="red/nodes.js"></script>
+<script src="red/storage.js"></script>
+<script src="red/history.js"></script>
+<script src="red/ui/keyboard.js"></script>
+<script src="red/ui/tabs.js"></script>
+<script src="red/ui/view.js"></script>
+<script src="red/ui/sidebar.js"></script>
+<script src="red/ui/palette.js"></script>
+<script src="red/ui/tab-info.js"></script>
+<script src="red/ui/tab-config.js"></script>
+<script src="red/ui/editor.js"></script>
+<script src="red/ui/library.js"></script>
+<script src="red/ui/notifications.js"></script>
+<script src="red/ui/touch/radialMenu.js"></script>
+
+<!--
+ TODO: generate some or all of this automatically from the C++ source
+-->
+
+<!--
+ TODO: add a field for maximum instance count
+-->
+<!--
+ TODO: add a field for exclusive to other objects (not allowed if they're used)
+-->
+<!--
+ TODO: add "parameters" fields, to replace the form html stuff
+-->
+
+<script  type="text/x-red" data-container-name="InputOutputCompatibilityMetadata">
+	{"requirements":[
+		{"type":"AudioInputI2S",         "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputI2S",         "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputI2S",         "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputI2SQuad",     "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputI2SQuad",     "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputI2SQuad",     "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputI2SQuad",     "resource":"OUT1D Pin",     "shareable":false},
+		{"type":"AudioInputI2SHex",      "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputI2SHex",      "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputI2SHex",      "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputI2SHex",      "resource":"OUT1D Pin",     "shareable":false},
+		{"type":"AudioInputI2SHex",      "resource":"OUT1C Pin",     "shareable":false},
+		{"type":"AudioInputI2SOct",      "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputI2SOct",      "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputI2SOct",      "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputI2SOct",      "resource":"OUT1D Pin",     "shareable":false},
+		{"type":"AudioInputI2SOct",      "resource":"OUT1C Pin",     "shareable":false},
+		{"type":"AudioInputI2SOct",      "resource":"OUT1B Pin",     "shareable":false},
+		{"type":"AudioInputI2Sslave",    "resource":"I2S Device",    "shareable":true,  "setting":"I2S Slave"},
+		{"type":"AudioInputI2Sslave",    "resource":"Sample Rate",   "shareable":true,  "setting":"LRCLK1 Control"},
+		{"type":"AudioInputI2Sslave",    "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputI2S2",        "resource":"I2S2 Device",   "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputI2S2",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputI2S2",        "resource":"IN2 Pin",       "shareable":false},
+		{"type":"AudioInputSPDIF3",      "resource":"SPDIF Device",  "shareable":true,  "setting":"SPDIF Protocol"},
+		{"type":"AudioInputSPDIF3",      "resource":"Sample Rate",   "shareable":true,  "setting":"SPDIF Control"},
+		{"type":"AudioInputSPDIF3",      "resource":"SPDIFIN Pin",   "shareable":false},
+		{"type":"AsyncAudioInputSPDIF3", "resource":"SPDIF Device",  "shareable":true,  "setting":"SPDIF Protocol"},
+		{"type":"AsyncAudioInputSPDIF3", "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AsyncAudioInputSPDIF3", "resource":"SPDIFIN Pin",   "shareable":false},
+		{"type":"AudioInputAnalog",      "resource":"ADC1",          "shareable":false},
+		{"type":"AudioInputAnalog",      "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputAnalogStereo","resource":"ADC1",          "shareable":false},
+		{"type":"AudioInputAnalogStereo","resource":"ADC2",          "shareable":false},
+		{"type":"AudioInputAnalogStereo","resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputPDM",         "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputPDM",         "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputPDM",         "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputPDM2",        "resource":"I2S2 Device",   "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioInputPDM2",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputPDM2",        "resource":"IN2 Pin",       "shareable":false},
+		{"type":"AudioInputTDM",         "resource":"I2S Device",    "shareable":true,  "setting":"TDM Protocol"},
+		{"type":"AudioInputTDM",         "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputTDM",         "resource":"IN1 Pin",       "shareable":false},
+		{"type":"AudioInputTDM2",        "resource":"I2S2 Device",   "shareable":true,  "setting":"TDM Protocol"},
+		{"type":"AudioInputTDM2",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioInputTDM2",        "resource":"IN2 Pin",       "shareable":false},
+		{"type":"AudioInputUSB",         "resource":"USB Rx Endpoint","shareable":false},
+		{"type":"AudioOutputI2S",        "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioOutputI2S",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputI2S",        "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputI2SQuad",    "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioOutputI2SQuad",    "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputI2SQuad",    "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputI2SQuad",    "resource":"OUT1B Pin",     "shareable":false},
+		{"type":"AudioOutputI2SHex",     "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioOutputI2SHex",     "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputI2SHex",     "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputI2SHex",     "resource":"OUT1B Pin",     "shareable":false},
+		{"type":"AudioOutputI2SHex",     "resource":"OUT1C Pin",     "shareable":false},
+		{"type":"AudioOutputI2SOct",     "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioOutputI2SOct",     "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputI2SOct",     "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputI2SOct",     "resource":"OUT1B Pin",     "shareable":false},
+		{"type":"AudioOutputI2SOct",     "resource":"OUT1C Pin",     "shareable":false},
+		{"type":"AudioOutputI2SOct",     "resource":"OUT1D Pin",     "shareable":false},
+		{"type":"AudioOutputI2Sslave",   "resource":"I2S Device",    "shareable":true,  "setting":"I2S Slave"},
+		{"type":"AudioOutputI2Sslave",   "resource":"Sample Rate",   "shareable":true,  "setting":"LRCLK1 Control"},
+		{"type":"AudioOutputI2Sslave",   "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputI2S2",       "resource":"I2S2 Device",   "shareable":true,  "setting":"I2S Master"},
+		{"type":"AudioOutputI2S2",       "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputI2S2",       "resource":"OUT2 Pin",      "shareable":false},
+		{"type":"AudioOutputSPDIF",      "resource":"I2S Device",    "shareable":true,  "setting":"SPDIF Protocol"},
+		{"type":"AudioOutputSPDIF",      "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputSPDIF",      "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputSPDIF2",     "resource":"I2S2 Device",   "shareable":true,  "setting":"SPDIF Protocol"},
+		{"type":"AudioOutputSPDIF2",     "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputSPDIF2",     "resource":"OUT2 Pin",      "shareable":false},
+		{"type":"AudioOutputSPDIF3",     "resource":"SPDIF Device",  "shareable":true,  "setting":"SPDIF Protocol"},
+		{"type":"AudioOutputSPDIF3",     "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputSPDIF3",     "resource":"SPDIFOUT Pin",  "shareable":false},
+		{"type":"AudioOutputPT8211",     "resource":"I2S Device",    "shareable":true,  "setting":"PT8211 Protocol"},
+		{"type":"AudioOutputPT8211",     "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputPT8211",     "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputPT8211_2",   "resource":"I2S2 Device",   "shareable":true,  "setting":"PT8211 Protocol"},
+		{"type":"AudioOutputPT8211_2",   "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputPT8211_2",   "resource":"OUT2 Pin",      "shareable":false},
+		{"type":"AudioOutputAnalog",     "resource":"DAC1",          "shareable":false},
+		{"type":"AudioOutputAnalog",     "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputAnalogStereo","resource":"DAC1",         "shareable":false},
+		{"type":"AudioOutputAnalogStereo","resource":"DAC2",         "shareable":false},
+		{"type":"AudioOutputAnalogStereo","resource":"Sample Rate",  "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputPWM",        "resource":"PWM",           "shareable":false},
+		{"type":"AudioOutputPWM",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputMQS",        "resource":"MSQ Device",    "shareable":false},
+		{"type":"AudioOutputMQS",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputTDM",        "resource":"I2S Device",    "shareable":true,  "setting":"TDM Protocol"},
+		{"type":"AudioOutputTDM",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputTDM",        "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputTDM2",       "resource":"I2S2 Device",   "shareable":true,  "setting":"TDM Protocol"},
+		{"type":"AudioOutputTDM2",       "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputTDM2",       "resource":"OUT2 Pin",      "shareable":false},
+		{"type":"AudioOutputADAT",       "resource":"I2S Device",    "shareable":true,  "setting":"ADAT Protocol"},
+		{"type":"AudioOutputADAT",       "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
+		{"type":"AudioOutputADAT",       "resource":"OUT1A Pin",     "shareable":false},
+		{"type":"AudioOutputUSB",        "resource":"USB Tx Endpoint","shareable":false}
+	]}
+</script>
+
+
+<script  type="text/x-red" data-container-name="NodeDefinitions">
+	{"nodes":[
+		{"type":"AudioInputI2S","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputI2SQuad","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s_quad","inputs":0,"outputs":4,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputI2SHex","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s_hex","inputs":0,"outputs":6,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputI2SOct","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s_oct","inputs":0,"outputs":8,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputI2Sslave","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2sslave","inputs":0,"outputs":2,"category":"input-function","color":"#F7D8F0","icon":"arrow-in.png"}},
+		{"type":"AudioInputI2S2","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s2","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputSPDIF3","data":{"defaults":{"name":{"value":"new"}},"shortName":"spdif3","inputs":0,"outputs":2,"category":"input-function","color":"#F7D8F0","icon":"arrow-in.png"}},
+		{"type":"AsyncAudioInputSPDIF3","data":{"defaults":{"name":{"value":"new"}},"shortName":"spdif_async","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputAnalog","data":{"defaults":{"name":{"value":"new"}},"shortName":"adc","inputs":0,"outputs":1,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputAnalogStereo","data":{"defaults":{"name":{"value":"new"}},"shortName":"adcs","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputPDM","data":{"defaults":{"name":{"value":"new"}},"shortName":"pdm","inputs":0,"outputs":1,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputPDM2","data":{"defaults":{"name":{"value":"new"}},"shortName":"pdm2","inputs":0,"outputs":1,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputTDM","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm","inputs":0,"outputs":16,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputTDM2","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm2","inputs":0,"outputs":16,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputUSB","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+
+		{"type":"AudioOutputI2S","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputI2SQuad","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s_quad","inputs":4,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputI2SHex","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s_hex","inputs":6,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputI2SOct","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s_oct","inputs":8,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputI2Sslave","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2sslave","inputs":2,"outputs":0,"category":"output-function","color":"#F7D8F0","icon":"arrow-in.png"}},
+		{"type":"AudioOutputI2S2","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s2","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputSPDIF","data":{"defaults":{"name":{"value":"new"}},"shortName":"spdif","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputSPDIF2","data":{"defaults":{"name":{"value":"new"}},"shortName":"spdif2","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputSPDIF3","data":{"defaults":{"name":{"value":"new"}},"shortName":"spdif3","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputPT8211","data":{"defaults":{"name":{"value":"new"}},"shortName":"pt8211","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputPT8211_2","data":{"defaults":{"name":{"value":"new"}},"shortName":"pt8211_2","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputAnalog","data":{"defaults":{"name":{"value":"new"}},"shortName":"dac","inputs":1,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputAnalogStereo","data":{"defaults":{"name":{"value":"new"}},"shortName":"dacs","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputPWM","data":{"defaults":{"name":{"value":"new"}},"shortName":"pwm","inputs":1,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputMQS","data":{"defaults":{"name":{"value":"new"}},"shortName":"mqs","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputTDM","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm","inputs":16,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputTDM2","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm2","inputs":16,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputADAT","data":{"defaults":{"name":{"value":"new"}},"shortName":"adat","inputs":8,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputUSB","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+
+		{"type":"AudioAmplifier","data":{"defaults":{"name":{"value":"new"}},"shortName":"amp","inputs":1,"outputs":1,"category":"mixer-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioMixer4","data":{"defaults":{"name":{"value":"new"}},"shortName":"mixer","inputs":4,"outputs":1,"category":"mixer-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioPlayMemory","data":{"defaults":{"name":{"value":"new"}},"shortName":"playMem","inputs":0,"outputs":1,"category":"play-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioPlaySdWav","data":{"defaults":{"name":{"value":"new"}},"shortName":"playSdWav","inputs":0,"outputs":2,"category":"play-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioPlaySdRaw","data":{"defaults":{"name":{"value":"new"}},"shortName":"playSdRaw","inputs":0,"outputs":1,"category":"play-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioPlaySerialflashRaw","data":{"defaults":{"name":{"value":"new"}},"shortName":"playFlashRaw","inputs":0,"outputs":1,"category":"play-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioPlayQueue","data":{"defaults":{"name":{"value":"new"}},"shortName":"queue","inputs":0,"outputs":1,"category":"play-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioRecordQueue","data":{"defaults":{"name":{"value":"new"}},"shortName":"queue","inputs":1,"outputs":0,"category":"record-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWavetable","data":{"defaults":{"name":{"value":"new"}},"shortName":"wavetable","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthSimpleDrum","data":{"defaults":{"name":{"value":"new"}},"shortName":"drum","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthKarplusStrong","data":{"defaults":{"name":{"value":"new"}},"shortName":"string","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWaveformSine","data":{"defaults":{"name":{"value":"new"}},"shortName":"sine","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWaveformSineHires","data":{"defaults":{"name":{"value":"new"}},"shortName":"sine_hires","inputs":0,"outputs":2,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWaveformSineModulated","data":{"defaults":{"name":{"value":"new"}},"shortName":"sine_fm","inputs":1,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWaveform","data":{"defaults":{"name":{"value":"new"}},"shortName":"waveform","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWaveformModulated","data":{"defaults":{"name":{"value":"new"}},"shortName":"waveformMod","inputs":2,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWaveformPWM","data":{"defaults":{"name":{"value":"new"}},"shortName":"pwm","inputs":1,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthToneSweep","data":{"defaults":{"name":{"value":"new"}},"shortName":"tonesweep","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthWaveformDc","data":{"defaults":{"name":{"value":"new"}},"shortName":"dc","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthNoiseWhite","data":{"defaults":{"name":{"value":"new"}},"shortName":"noise","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioSynthNoisePink","data":{"defaults":{"name":{"value":"new"}},"shortName":"pink","inputs":0,"outputs":1,"category":"synth-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectFade","data":{"defaults":{"name":{"value":"new"}},"shortName":"fade","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectChorus","data":{"defaults":{"name":{"value":"new"}},"shortName":"chorus","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectFlange","data":{"defaults":{"name":{"value":"new"}},"shortName":"flange","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectReverb","data":{"defaults":{"name":{"value":"new"}},"shortName":"reverb","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectFreeverb","data":{"defaults":{"name":{"value":"new"}},"shortName":"freeverb","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectFreeverbStereo","data":{"defaults":{"name":{"value":"new"}},"shortName":"freeverbs","inputs":1,"outputs":2,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectEnvelope","data":{"defaults":{"name":{"value":"new"}},"shortName":"envelope","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectMultiply","data":{"defaults":{"name":{"value":"new"}},"shortName":"multiply","inputs":2,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectRectifier","data":{"defaults":{"name":{"value":"new"}},"shortName":"rectify","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectDelay","data":{"defaults":{"name":{"value":"new"}},"shortName":"delay","inputs":1,"outputs":8,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectDelayExternal","data":{"defaults":{"name":{"value":"new"}},"shortName":"delayExt","inputs":1,"outputs":8,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectBitcrusher","data":{"shortName":"bitcrusher","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectMidSide","data":{"shortName":"midside","inputs":2,"outputs":2,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectWaveshaper","data":{"shortName":"waveshape","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectGranular","data":{"shortName":"granular","inputs":1,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectDigitalCombine","data":{"shortName":"combine","inputs":2,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioEffectWaveFolder","data":{"defaults":{"name":{"value":"new"}},"shortName":"wavefolder","inputs":2,"outputs":1,"category":"effect-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioFilterBiquad","data":{"defaults":{"name":{"value":"new"}},"shortName":"biquad","inputs":1,"outputs":1,"category":"filter-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioFilterFIR","data":{"defaults":{"name":{"value":"new"}},"shortName":"fir","inputs":1,"outputs":1,"category":"filter-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioFilterStateVariable","data":{"defaults":{"name":{"value":"new"}},"shortName":"filter","inputs":2,"outputs":3,"category":"filter-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioFilterLadder","data":{"defaults":{"name":{"value":"new"}},"shortName":"ladder","inputs":3,"outputs":1,"category":"filter-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioAnalyzePeak","data":{"defaults":{"name":{"value":"new"}},"shortName":"peak","inputs":1,"outputs":0,"category":"analyze-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioAnalyzeRMS","data":{"defaults":{"name":{"value":"new"}},"shortName":"rms","inputs":1,"outputs":0,"category":"analyze-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioAnalyzeFFT256","data":{"defaults":{"name":{"value":"new"}},"shortName":"fft256","inputs":1,"outputs":0,"category":"analyze-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioAnalyzeFFT1024","data":{"defaults":{"name":{"value":"new"}},"shortName":"fft1024","inputs":1,"outputs":0,"category":"analyze-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioAnalyzeToneDetect","data":{"defaults":{"name":{"value":"new"}},"shortName":"tone","inputs":1,"outputs":0,"category":"analyze-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioAnalyzeNoteFrequency","data":{"defaults":{"name":{"value":"new"}},"shortName":"notefreq","inputs":1,"outputs":0,"category":"analyze-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioAnalyzePrint","data":{"defaults":{"name":{"value":"new"}},"shortName":"print","inputs":1,"outputs":0,"category":"analyze-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioControlSGTL5000","data":{"defaults":{"name":{"value":"new"}},"shortName":"sgtl5000","inputs":0,"outputs":0,"category":"control-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioControlAK4558","data":{"defaults":{"name":{"value":"new"}},"shortName":"ak4558","inputs":0,"outputs":0,"category":"control-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioControlCS4272","data":{"defaults":{"name":{"value":"new"}},"shortName":"cs4272","inputs":0,"outputs":0,"category":"control-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioControlWM8731","data":{"defaults":{"name":{"value":"new"}},"shortName":"wm8731","inputs":0,"outputs":0,"category":"control-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioControlWM8731master","data":{"defaults":{"name":{"value":"new"}},"shortName":"wm8731m","inputs":0,"outputs":0,"category":"control-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioControlCS42448","data":{"defaults":{"name":{"value":"new"}},"shortName":"cs42448","inputs":0,"outputs":0,"category":"control-function","color":"#E6E0F8","icon":"arrow-in.png"}}
+	]}
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputI2S">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 16 bit stereo audio from the
+	<a href="http://www.pjrc.com/store/teensy3_audio.html" target="_blank">audio shield</a>
+		or another I2S device, using I2S master mode.</p>
+	<p align=center><img src="img/audioshield_inputs.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the I2S hardware to its 2 output ports.</p>
+	<h3>Hardware Teensy 4</h3>
+	<h3>Hardware Teensy 3</h3>
+	<p align=center><img src="img/audioshield_backside.jpg"></p>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T3.x<br>Pin</th><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>11</td><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>13</td><td align=center>8</td><td>RX</td><td>Input</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<p>Audio from
+		master mode I2S may be used in the same project as ADC, DAC and
+		PWM signals, because all remain in sync to Teensy's timing</p>
+	<p>Compatible CODEC Chips:
+		<ul>
+		<li><a href="https://www.pjrc.com/store/teensy3_audio.html">STGL5000</a>
+		<li><a href="https://forum.pjrc.com/threads/42665-New-Audio-Board!-TI-TLV320AIC3206">TLV320AIC3206</a>
+		<li><a href="https://forum.pjrc.com/threads/32276-HiFi-Audio-CODEC-Module-AK4558-evaluation-board-in-a-square-inch-PCB">AK4558</a>
+		<li>WM8731
+		</ul>
+	</p>
+	<p>Compatible ADC Chips:
+		<ul>
+		</ul>
+	</p>
+	<p>Compatible Microphones:
+		<ul>
+		<li><a href="https://forum.pjrc.com/threads/47010-I2S-Microphone-(SPH0645LM4H-B)?p=157101&viewfull=1#post157101">SPH0645LM4H-B</a>
+		<li><a href="https://forum.pjrc.com/threads/50534-Why-MEMS-i2s-microphone-ICS-43432-with-teensy-audio-library-not-working?p=173279&viewfull=1#post173279">ICS43432</a>
+		<li><a href="https://forum.pjrc.com/threads/49065-ICS43434-I2S-Digital-Microphone-and-Teensy-3-2">ICS43434</a>
+		</ul>
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughStereo
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Recorder
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; PeakMeterStereo
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; FFT
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; SpectrumAnalyzerBasic
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Chorus
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Flange
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Filter
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Filter_FIR
+	</p>
+	<h3>Notes</h3>
+	<p>Normally, this object is used with the Audio Shield, which
+		is controlled separately by the "sgtl5000" object.</p>
+	<p>Only one I2S input and one I2S output object may be used.  Master
+		and slave modes may not be mixed (both must be of the same type).
+	</p>
+	<p>I2S master objects can be used together with non-I2S input and output
+		objects, for simultaneous audio streaming on different hardware.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputI2S">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputI2SQuad">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 16 bit quad (4) channel audio from two
+	<a href="http://www.pjrc.com/store/teensy3_audio.html" target="_blank">audio shields</a>
+		or another I2S devices, using I2S master mode.</p>
+	<p align=center><img src="img/audioshield_quad_in.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Channel #1</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Channel #2</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Channel #3</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Channel #4</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the I2S hardware to its 4 output ports.</p>
+	<h3>Hardware</h3>
+	<p>See this Sparkfun blog for <a href="https://www.sparkfun.com/news/2055" target="_blank">how
+		to connect two audio adaptors for 4 channel audio</a>.</p>
+	<p>For Teensy 4 and Rev D audio shields, see
+		<a href="https://forum.pjrc.com/threads/61123?p=242054&viewfull=1#post242054">this forum thread</a>.</p>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>3.2<br>Pin</th><th>Teensy<br>3.5/3.6<br>Pin</th><th>Teensy<br>4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>11</td><td align=center>11</td><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>13</td><td align=center>13</td><td align=center>8</td><td>RX</td><td>Input</td></tr>
+		<tr class=odd><td align=center>30</td><td align=center>38</td><td align=center>6</td><td>RX</td><td>Input</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>23</td><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<p>Audio from
+		master mode I2S may be used in the same project as ADC, DAC and
+		PWM signals, because all remain in sync to Teensy's timing</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughQuad
+	</p>
+	<h3>Notes</h3>
+	<p>On Teensy 3.x, the BCLK/LRCLK ratio is 32, which is not compatible with
+		most MEMS microphones.  Teensy 4.x uses BCLK/LRCLK ratio, which can
+		be used with I2S MEMS microphones.</p>
+	<p>Normally, this object is used with two Audio Shield, which
+		are controlled separately by a pair "sgtl5000" object.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputI2SQuad">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputI2SHex">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 6 channel audio from three I2S devices, using I2S master mode.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Channel #1</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Channel #2</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Channel #3</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Channel #4</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Channel #5</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Channel #6</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the I2S hardware to its 6 output ports.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>8</td><td>RX (ch 1+2)</td><td>Input</td></tr>
+		<tr class=odd><td align=center>6</td><td>RX (ch 3+4)</td><td>Input</td></tr>
+		<tr class=odd><td align=center>9</td><td>RX (ch 5+6)</td><td>Input</td></tr>
+		<tr class=odd><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<!--<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughQuad
+	</p>-->
+	<h3>Notes</h3>
+	<p>Teensy 4.0 &amp; 4.1's I2S port has a total of 5 data pins
+		which may each transmit or receive stereo digital audio.  This
+		6 channel input may be used together with the I2S stereo or
+		quad channel I2S output, but may not be combined with others
+		which use the same physical pins.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputI2SHex">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputI2SOct">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 8 channel audio from three I2S devices, using I2S master mode.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Channel #1</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Channel #2</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Channel #3</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Channel #4</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Channel #5</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Channel #6</td></tr>
+		<tr class=odd><td align=center>Out 6</td><td>Channel #7</td></tr>
+		<tr class=odd><td align=center>Out 7</td><td>Channel #8</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the I2S hardware to its 8 output ports.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>8</td><td>RX (ch 1+2)</td><td>Input</td></tr>
+		<tr class=odd><td align=center>6</td><td>RX (ch 3+4)</td><td>Input</td></tr>
+		<tr class=odd><td align=center>9</td><td>RX (ch 5+6)</td><td>Input</td></tr>
+		<tr class=odd><td align=center>32</td><td>RX (ch 7+8)</td><td>Input</td></tr>
+		<tr class=odd><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<!--<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughQuad
+	</p>-->
+	<h3>Notes</h3>
+	<p>Teensy 4.0 &amp; 4.1's I2S port has a total of 5 data pins
+		which may each transmit or receive stereo digital audio.  This
+		8 channel input may be used together with the I2S stereo
+		output, but may not be combined with others
+		which use the same physical pins.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputI2SOct">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputI2S2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 16 bit stereo audio from an I2S device using the 2nd I2S port on Teensy 4.x.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the I2S hardware to its 2 output ports.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>4</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>33</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>5</td><td>RX</td><td>Input</td></tr>
+		<tr class=odd><td align=center>3</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	</p>
+	<h3>Examples</h3>
+	<h3>Notes</h3>
+</script>
+<script type="text/x-red" data-template-name="AudioInputI2S2">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+<script type="text/x-red" data-help-name="AudioInputSPDIF3">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive S/PDIF digital audio, at the rate of the external digital audio source.</p>
+	<p><span style="color:red">This input is incompatible with most other inputs and outputs</span>
+		which run at a speed controlled by Teensy's internal sample rate.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>pllLocked</span>();</p>
+	<p class=desc>Returns true if the S/PDIF phase locked loop is tracking
+		the sample rate of incoming digital audio data.
+	</p>
+	<p class=func><span class=keyword>sampleRate</span>();</p>
+	<p class=desc>Returns the sample rate of incoming data, if the PLL has locked,
+		or returns 0 if the audio sample rate is unknown.
+	</p>
+	<h3>Hardware</h3>
+	<p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>15</td><td>S/PDIF Data</td><td>Output</td></tr>
+	</table>
+	</p>
+	<h3>Examples</h3>
+	<!--<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughAsyncSpdif
+	</p>-->
+	<h3>Notes</h3>
+	<p>This input tries to force the entire audio library to run at the
+		sample rate of the incoming data.  It usually can not be combined
+		with most other inputs and outputs which run at specific speeds.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputSPDIF3">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AsyncAudioInputSPDIF3">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive S/PDIF digital audio and resample to Teensy's audio sample rate.</p>
+	<p>Asynchronous resampling contributed by <a href="https://github.com/alex6679">Alex Walch</a>.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>getBufferedTime</span>();</p>
+	<p class=desc>Returns the buffered time in seconds. The buffered time is the duration of the incoming samples which are not resampled yet. The step width of the resampling algorithm is constantly slightly adjusted to keep the buffered time closely to the target latency. The difference between the target latency and the buffered time is typically smaller than 1 microsecond.
+	</p>
+	<!--<p class=func><span class=keyword>getInputFrequency</span>();</p>
+	<p class=desc>TODO: documentation needed here
+	</p>-->
+	<p class=func><span class=keyword>isLocked</span>();</p>
+	<p class=desc>Returns true if the S/PDIF phase locked loop is tracking
+		the sample rate of incoming digital audio data.
+	</p>
+	<p class=func><span class=keyword>getInputFrequency</span>();</p>
+	<p class=desc>Returns the sample rate of incoming data, if the PLL has locked, or returns 0 if the audio sample rate is unknown.
+	</p>
+	<p class=func><span class=keyword>getTargetLantency</span>();</p>
+	<p class=desc>Returns the target latency in seconds. The latency is the time from the moment a sample is received by the Teensy SPDIF hardware receiver until it is transmitted by the asrc intput. The audio samples arrive at the asrc input in chunks of 32 samples per channel. The target latency consists of these 32 samples + some buffer that is needed to compensate for timing variations.
+	</p>
+	<p class=func><span class=keyword>getAttenuation</span>();</p>
+	<p class=desc>
+Returns the actual achieved attenuation of the anti-aliasing filter. If the input sampling rate is smaller or equal to 44.1kHz, no low pass filtering is needed and zero is returned.
+	</p>
+	<p class=func><span class=keyword>getHalfFilterLength</span>();</p>
+	<p class=desc>Returns the half length of the resampling filter. Its complete length is 2*(the returned value)+1.
+	</p>
+	<h3>Hardware</h3>
+	<p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>15</td><td>S/PDIF Data</td><td>Output</td></tr>
+	</table>
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughAsyncSpdif
+	</p>
+	<h3>Notes</h3>
+	<p>AsyncAudioInputSPDIF3 is not able to clock the audio pipline (never has the 'update_responsibility'). At least 1 other input or output must be used to cause the entire Audio library to update.
+	</p>
+
+	<p>AsyncAudioInputSPDIF3 can optionally take parameters to alter its resampling behavior.
+	</p>
+	<p><span class=keyword>AsyncAudioInputSPDIF3</span>  spdif_async1(<i>dither</i>, <i>noiseshaping</i>, <i>attenuation</i>, <i>minHalfFilterLength</i>, <i>maxHalfFilterLength</i>);
+	</p>
+	<p class=desc><i>dither</i>: triangular shaped dither is added at the transition from 32bit float to 16bit integer if true (default: true)
+	</p>
+	<p class=desc><i>noiseshaping</i>: noise shaping is applied at the aforementioned transition if true (default: true)
+	</p>
+	<p class=desc><i>attenuation</i>: target attenuation of the anti-aliasing filter (default: 100dB). The attenuation is not reached if a filter longer than 161 is needed.
+	</p>
+	<p class=desc><i>minHalfFilterLength</i>: half of the guaranteed resampling filter (internally restricted to 80, default: 20). The filter might be longer if needed to achieve the requested attenuation.
+	</p>
+	<p class=desc><i>maxHalfFilterLength</i>: Restricts the maximum length of the resampling filter. The maximum half filter length is 80. This parameter can be used to further restrict the length in order to limit the processor usage.
+	</p>
+	<p>The windowed (Kaiser window) sinc-function is used as resample filter (i.e. to interpolate the incoming signal). The longer the filter, the better the quality of the resampled signal. However, a longer filter has a higher group delay and increases the processor usage. The sinc- filter also serves as anti-aliasing filter if the input sample rate is larger than 44.1kHz. The filter length is automatically increased at high input sample rates to reach the specified attenuation. However its half length is restricted to 80. 32bit floating point arithmetic is used at the resampling stage and the resampled signal is transformed to 16 bit integers afterwards. Here it is possible to apply triangular shaped dither and noise shaping to increase the perceived signal-to-noise-ratio.</p>
+</script>
+<script type="text/x-red" data-template-name="AsyncAudioInputSPDIF3">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputAnalog">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive audio using the built-in analog to digital converter.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Audio Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the ADC to its output port.</p>
+	<h3>Hardware Teensy 4</h3>
+	<p>Pin A2 is used by default for audio input.</p>
+	<p>The same circuitry as Teensy 3 can be used (see schematic below),
+		but the 10K resistor should be changed to 2.2K.
+	<p>Signal range is 0 to 3.3V.</p>
+	<p>Low impedance (strong) drive is required.  The ADC pin picks up
+		a lot of noise from inside the chip.  A strong signal is
+		needed to overcome this noise coupling.  DO NOT leave the
+		input pin disconnected.  Strong noise will occur if the
+		ADC input pin is left floating!</p>
+	<h3>Hardware Teensy 3</h3>
+	<p>Pin A2 is used for audio input.  This circuitry is recommended.</p>
+	<p align=center><img src="img/adccircuit.png"></p>
+	<p>Signal range is 0 to 1.2V</p>
+	<p>With a <a href="https://forum.pjrc.com/threads/40468-Help-with-Basic-Audio-Lib-results?p=126317&viewfull=1#post126317">small modification</a> Adafruit's <a href="https://www.adafruit.com/products/1063">MAX4466 microphone</a> can be used</p>
+	<p align=center><a href="https://forum.pjrc.com/threads/40468-Help-with-Basic-Audio-Lib-results?p=126317&viewfull=1#post126317"><img src="img/adccircuitmic.jpg" border=0></a></p>
+	<p>Control Voltage (CV) from +5V to -5V can be adapted with a
+		<a href="https://www.dorkbotpdx.org/blog/paul/control_voltage_cv_to_analog_input_pin">simple circuit</a>
+		or better <a href="https://forum.pjrc.com/threads/28423?p=71257&viewfull=1#post71257">opamp-based circuity</a>
+		to Teensy's 0-1.2V analog input range.</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughMono
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; PeakMeterMono
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; DialTone_7segment
+	</p>
+	<p class=exam>File &gt; Examples &gt; OctoWS2811 &gt; SpectrumAnalyzer
+	</p>
+	<h3>Notes</h3>
+	<p><b>analogRead() must not be used</b>, on Teensy 3.x because AudioInputAnalog
+		is regularly
+		accessing the ADC hardware.  If both access the hardware at the same
+		moment, analogRead() can end up waiting forever, which effectively
+		crashes your program.
+	</p>
+	<p><b>analogRead()</b> can be used on Teensy 4.x while AudioInputAnalog is
+		running, as long as pins 26/A12, 27/A13, 38/A14, 39/A15 are not used.</p>
+	<p>A different pin may be used, but adding it as an parameter
+		to the AudioInputAnalog object definition.
+	</p>
+	<p>For example, to use pin A3:
+	</p>
+	<p class=desc><span class=keyword>AudioInputAnalog</span>  adc1(<span class=literal>A3</span>);
+	</p>
+	<p>On Teensy 4, analog pins 24/A10 and 25/A11 are not supported.</p>
+
+	<p>Noise due to high source impedance, which allows rapidly switching digital signals
+		to capacitively couple... avoiding higher analog impedance is the solution.</p>
+	<p>Power Supply rejection issue with simple DC bias (bigger capacitor may be needed if 3.3V has low frequency noise)</p>
+	<p>Algorithm for automatic DC bias tracking</p>
+	<p>Noise coupling from digital circuitry inside the chip is always a problem when using
+		ADC inputs pin.  It's never as quiet as the audio shield and any good quality
+		audio ADC chip.  Stong low impedance drive to the analog input pin is critical
+		to minimizing noise coupling.  If an opamp is used, connect a low value resistor
+		(eg, 100 to 1000 ohms)
+		between the opamp output and ADC input pin, and a 1nF capacitor from the ADC pin
+		to GND or AGND.  The capacitor lowers the impedance for high frequency noise,
+		and most opamps require a resistor to avoid oscillation when driving a
+		capacitive load.  Strong drive from an opamp, 100 ohm resistor and 1nF
+		capacitor can greatly reduce the digital noise coupling.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputAnalog">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputAnalogStereo">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive stereo audio using the built-in analog to digital converters.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Audio Channel (Left)</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Audio Channel (Right)</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from both ADCs to its output ports.</p>
+	<h3>Hardware</h3>
+	<p>By default, pins A2 & A3 are used for audio input.  This circuitry is recommended.</p>
+	<p align=center><img src="img/adccircuit2.png"></p>
+	<p>Signal range is 0 to 1.2V</p>
+	<p>Control Voltage (CV) from +5V to -5V can be adapted with a
+		<a href="https://www.dorkbotpdx.org/blog/paul/control_voltage_cv_to_analog_input_pin">simple circuit</a>
+		or better <a href="https://forum.pjrc.com/threads/28423?p=71257&viewfull=1#post71257">opamp-based circuity</a>
+		to Teensy's 0-1.2V analog input range.</p>
+	<h3>Examples</h3>
+	<!--
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughMono
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; PeakMeterMono
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; DialTone_7segment
+	</p>
+	<p class=exam>File &gt; Examples &gt; OctoWS2811 &gt; SpectrumAnalyzer
+	</p>
+	-->
+	<h3>Notes</h3>
+	<p><b>analogRead() must not be used</b>, because AudioInputAnalogStereo is regularly
+		accessing the ADC hardware.  If both access the hardware at the same
+		moment, analogRead() can end up waiting forever, which effectively
+		crashes your program.
+	</p>
+	<p>A different pin may be used, but adding it as an parameter
+		to the AudioInputAnalog object definition.
+	</p>
+	<p>For example:
+	</p>
+	<p class=desc><span class=keyword>AudioInputAnalogStereo</span>  adc1(<span class=literal>A3</span>, <span class=literal>A2</span>);
+	</p>
+	<p>TODO: add info here about which pins work for input 0 and 1.
+	</p>
+	<p>Noise due to high source impedance, which allows rapidly switching digital signals
+		to capacitively couple... avoiding higher analog impedance is the solution.</p>
+	<p>Power Supply rejection issue with simple DC bias (bigger capacitor may be needed if 3.3V has low frequency noise)</p>
+	<p>Algorithm for automatic DC bias tracking</p>
+	<p>TODO: actual noise measurements with different input circuitry
+		(it's not as quiet as the audio shield)</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputAnalogStereo">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputI2Sslave">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 16 bit stereo audio from an I2S device using I2S slave mode
+		(where the ADC or codec chip, not Teensy, controls audio timing).</p>
+	<p><span style="color:red">This input is incompatible with most other inputs and outputs</span>
+		which run at a speed controlled by Teensy's internal sample rate.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the I2S hardware to its 2 output ports.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "slave" mode, where the I2S device controls
+		data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>3.x Pin</th><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Input</td></tr>
+		<tr class=odd><td align=center>13</td><td align=center>8</td><td>RX</td><td>Input</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>LRCLK</td><td>Input</td></tr>
+	</table>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>Slave mode I2S <b>should not used in the same project as ADC, DAC and
+		PWM</b> signals.  Differences in timing between the I2S device and
+		Teensy's clock can cause occasional audio glitches when I2S slave mode
+		is used together with other input or output objects based on Teensy's
+		timing.</p>
+	<p>Only one I2S input and one I2S output object may be used.  Master
+		and slave modes may not be mixed (both must be of the same type).
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputI2Sslave">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputTDM">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive a 256 bit Time Division Multiplexed frame containing
+		many audio channels.</p>
+	<p align=center><img src="img/tdm.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Bits 0 to 15</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Bits 16 to 31</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Bits 32 to 47</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Bits 48 to 63</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Bits 64 to 79</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Bits 80 to 95</td></tr>
+		<tr class=odd><td align=center>Out 6</td><td>Bits 96 to 111</td></tr>
+		<tr class=odd><td align=center>Out 7</td><td>Bits 112 to 127</td></tr>
+		<tr class=odd><td align=center>Out 8</td><td>Bits 128 to 143</td></tr>
+		<tr class=odd><td align=center>Out 9</td><td>Bits 144 to 159</td></tr>
+		<tr class=odd><td align=center>Out 10</td><td>Bits 160 to 175</td></tr>
+		<tr class=odd><td align=center>Out 11</td><td>Bits 176 to 191</td></tr>
+		<tr class=odd><td align=center>Out 12</td><td>Bits 192 to 207</td></tr>
+		<tr class=odd><td align=center>Out 13</td><td>Bits 208 to 223</td></tr>
+		<tr class=odd><td align=center>Out 14</td><td>Bits 224 to 239</td></tr>
+		<tr class=odd><td align=center>Out 15</td><td>Bits 240 to 255</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the TDM hardware to its 16 output ports.</p>
+	<h3>Hardware</h3>
+	<p>TDM has been tested with this
+		<a href="https://oshpark.com/shared_projects/2Yj6rFaW">
+		CS42448 Board for Teensy 3.x</a> and this
+		<a href="https://oshpark.com/shared_projects/gVFy0fWQ">
+		CS42448 Board for Teensy 4.x</a>.  It may also work with
+		<a href="https://forum.pjrc.com/threads/42894">Invensense ICS-52000 microphones</a>.
+		</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T3.x<br>Pin</th><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Output, 11.3 MHz</td></tr>
+		<tr class=odd><td align=center>11</td><td align=center>23</td><td>MCLK</td><td>Output, 22.6 MHz</td></tr>
+		<tr class=odd><td align=center>13</td><td align=center>8</td><td>RX</td><td>Input, 11.3 Mbit/sec</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>FS</td><td>Output</td></tr>
+	</table>
+	<p>Audio from
+		master mode TDM may be used in the same project as ADC, DAC and
+		PWM signals, because all remain in sync to Teensy's timing</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughTDM16</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Only one TDM input and one TDM output object may be used.  The
+		I2S hardware is used by TDM, so TDM objects may not be used
+		together with I2S, SPDIF or PT8211.</p>
+	<p>When used with TDM devices which transmit 32 bit audio, the
+		even numbered channels will contain the useful upper 16
+		bits of audio data.</p>
+	<p>AudioMemory should be at least 16.  Even if most channels are
+		unused, this TDM object will need to allocate 16 blocks of
+		memory.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputTDM">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputTDM2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive a 256 bit Time Division Multiplexed frame containing
+		many audio channels, using the I2S2 port.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Bits 0 to 15</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Bits 16 to 31</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Bits 32 to 47</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Bits 48 to 63</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Bits 64 to 79</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Bits 80 to 95</td></tr>
+		<tr class=odd><td align=center>Out 6</td><td>Bits 96 to 111</td></tr>
+		<tr class=odd><td align=center>Out 7</td><td>Bits 112 to 127</td></tr>
+		<tr class=odd><td align=center>Out 8</td><td>Bits 128 to 143</td></tr>
+		<tr class=odd><td align=center>Out 9</td><td>Bits 144 to 159</td></tr>
+		<tr class=odd><td align=center>Out 10</td><td>Bits 160 to 175</td></tr>
+		<tr class=odd><td align=center>Out 11</td><td>Bits 176 to 191</td></tr>
+		<tr class=odd><td align=center>Out 12</td><td>Bits 192 to 207</td></tr>
+		<tr class=odd><td align=center>Out 13</td><td>Bits 208 to 223</td></tr>
+		<tr class=odd><td align=center>Out 14</td><td>Bits 224 to 239</td></tr>
+		<tr class=odd><td align=center>Out 15</td><td>Bits 240 to 255</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the TDM hardware to its 16 output ports.</p>
+	<h3>Hardware</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>4</td><td>BCLK</td><td>Output, 11.3 MHz</td></tr>
+		<tr class=odd><td align=center>33</td><td>MCLK</td><td>Output, 22.6 MHz</td></tr>
+		<tr class=odd><td align=center>5</td><td>RX</td><td>Input, 11.3 Mbit/sec</td></tr>
+		<tr class=odd><td align=center>3</td><td>FS</td><td>Output</td></tr>
+	</table>
+	<!--<h3>Examples</h3>-->
+	<h3>Notes</h3>
+	<p>When used with TDM devices which transmit 32 bit audio, the
+		even numbered channels will contain the useful upper 16
+		bits of audio data.</p>
+	<p>AudioMemory should be at least 16.  Even if most channels are
+		unused, this TDM object will need to allocate 16 blocks of
+		memory.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputTDM2">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputPDM">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive (and filter) a Pulse Density Modulated bitstream.
+		</p>
+	<p align=center><img src="img/pdmmic.jpg"><br><small>PDM MEMS Mic</small></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Filtered Audio Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the PDM data, filters out the high frequency
+		noise and gives you the audio signal.</p>
+	<h3>Hardware</h3>
+	<p>PDM has been tested with this <a href="https://www.adafruit.com/product/3492">
+		Adafruit MP34DT01-M Microphone Board</a>.
+	</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T3.x Pin</th><th>T4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>CLK</td><td>Output, 2.8235 MHz</td></tr>
+		<tr class=odd><td align=center>13</td><td align=center>8</td><td>DATA</td><td>Input, Data on rising edge</td></tr>
+	</table>
+
+	<p>Data is input on the rising edge.  The SEL pin on MP34DT01-M should be
+		connected LOW for proper data capture.</p>
+	<!--<h3>Examples</h3>-->
+	<h3>Notes</h3>
+	<p>On the T3 filtering consumes approximately 39% of the CPU when running at
+		96 MHz.  The code currently consumes this time inside a high
+		priority interrupt, blocking other libraries.  Perhaps future
+	  versions will perform filtering at lower priority.  The CPU usage is less
+	  burdensome for the T4.
+		</p>
+	<p>The filter used is a 512 tap FIR with approx &plusmn;1.1 dB gain
+		flatness to 10 kHz.  While far from audiophile grade, this should
+		perform far better than the rapid rolloff of Cascaded Integrator
+		Comb (CIC) or simple moving average filters commonly used on
+		other microcontrollers.  The filter also consumes 2104 bytes of
+		RAM for buffering and 32K of Flash for a lookup table to optimized
+		the filter computation.
+		</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputPDM">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+<script type="text/x-red" data-help-name="AudioInputPDM2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive (and filter) a Pulse Density Modulated bitstream from I2S2 unit.
+		</p>
+	<p align=center><img src="img/pdmmic.jpg"><br><small>PDM MEMS Mic, using I2S2</small></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Filtered Audio Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the PDM data, filters out the high frequency
+		noise and gives you the audio signal.</p>
+	<h3>Hardware</h3>
+	<p>PDM2 has been tested with this <a href="https://www.adafruit.com/product/3492">
+		Adafruit MP34DT01-M Microphone Board</a>.
+	</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T4.x Pin I2S2</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>4</td><td>CLK</td><td>Output, 2.8235 MHz</td></tr>
+		<tr class=odd><td align=center>5</td><td>DATA</td><td>Input, Data on rising edge</td></tr>
+	</table>
+
+	<p>Data is input on the rising edge.  The SEL pin on MP34DT01-M should be
+		connected LOW for proper data capture.</p>
+	<!--<h3>Examples</h3>-->
+	<h3>Notes</h3>
+        <p>This uses the alternate I2S2 unit on the T4, employing the BCLK2 and IN2 pins, 
+	   allowing AudioInputI2S to be run alongside.</p>
+	<p>The filter used is a 512 tap FIR with approx &plusmn;1.1 dB gain
+		flatness to 10 kHz.  While far from audiophile grade, this should
+		perform far better than the rapid rolloff of Cascaded Integrator
+		Comb (CIC) or simple moving average filters commonly used on
+		other microcontrollers.  The filter also consumes 2104 bytes of
+		RAM for buffering and 32K of Flash for a lookup table to optimized
+		the filter computation.
+		</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputPDM2">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioInputUSB">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive stereo audio from a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_in.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>volume</span>();</p>
+	<p class=desc>Returns the volume setting requested by the USB host.
+		Range is 0 to 1.0.  To make the PC's volume control work, this
+		setting should be read periodically and used to control the
+		system processing the signal.
+	</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughUSB</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioInputUSB">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputI2S">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio to the
+	<a href="http://www.pjrc.com/store/teensy3_audio.html" target="_blank">audio shield</a>
+		or another I2S device, using I2S master mode.</p>
+	<p align=center><img src="img/audioshield_outputs.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports to the I2S hardware.</p>
+	<h3>Hardware</h3>
+	<p align=center><img src="img/audioshield_backside.jpg"></p>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T3.x<br>Pin</th><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>11</td><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>22</td><td align=center>7</td><td>TX</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<p>Audio from
+		master mode I2S may be used in the same project as ADC, DAC and
+		PWM signals, because all remain in sync to Teensy's timing</p>
+	<p>Compatible CODEC Chips:
+		<ul>
+		<li><a href="https://www.pjrc.com/store/teensy3_audio.html">STGL5000</a>
+		<li><a href="https://forum.pjrc.com/threads/42665-New-Audio-Board!-TI-TLV320AIC3206">TLV320AIC3206</a>
+		<li><a href="https://forum.pjrc.com/threads/32276-HiFi-Audio-CODEC-Module-AK4558-evaluation-board-in-a-square-inch-PCB">AK4558</a>
+		</ul>
+	</p>
+	<p>Compatible DAC Chips:
+		<ul>
+		<li><a href="https://forum.pjrc.com/threads/53069-Teensy-with-PCM5102a-Module-via-I2S?p=183106&viewfull=1#post183106">PCM5102A</a>
+		<li><a href="https://forum.pjrc.com/threads/53069-Teensy-with-PCM5102a-Module-via-I2S?p=183176&viewfull=1#post183176">PCM1808</a>
+		<li><a href="https://forum.pjrc.com/threads/53069-Teensy-with-PCM5102a-Module-via-I2S?p=188244&viewfull=1#post188244">PCM5242</a>
+		<li><a href="https://forum.pjrc.com/threads/55137-I2S-output-with-CS4344?p=197919&viewfull=1#post197919">CS4344</a>
+		</ul>
+	</p>
+	<h3>Examples</h3>
+	<p>Nearly all the examples use this object.  Here are some of the highlights:</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughStereo
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; SamplePlayer
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Recorder
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; WavFilePlayer
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Chorus
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; PlaySynthMusic
+	</p>
+	<h3>Notes</h3>
+	<p>Normally, this object is used with the Audio Shield, which
+		is controlled separately by the "sgtl5000" object.</p>
+	<p>Only one I2S input and one I2S output object may be used.  Master
+		and slave modes may not be mixed (both must be of the same type).
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputI2S">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputI2SQuad">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit quad (4) channel 16 bit audio, using I2S master mode.</p>
+	<p align=center><img src="img/audioshield_quad_out.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Channel #1</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Channel #2</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Channel #3</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Channel #4</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 4 input ports to the I2S hardware.</p>
+	<h3>Hardware</h3>
+	<p>See this Sparkfun blog for <a href="https://www.sparkfun.com/news/2055" target="_blank">how
+		to connect two audio adaptors for 4 channel audio</a>.  More
+		<a href="https://forum.pjrc.com/threads/29373-Bit-bang-multiple-I2S-inputs-simultaneously?p=79606#post79606" target="_blank">details</a> are also available.</p>
+	<p>For Teensy 4 and Rev D audio shields, see
+		<a href="https://forum.pjrc.com/threads/61123?p=242054&viewfull=1#post242054">this forum thread</a>.</p>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T3.x<br>Pin</th><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>11</td><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>22</td><td align=center>7</td><td>TX (ch 1+2)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>15</td><td align=center>32</td><td>TX (ch 3+4)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<p>Audio from
+		master mode I2S may be used in the same project as ADC, DAC and
+		PWM signals, because all remain in sync to Teensy's timing</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughQuad
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; SGTL5000 &gt; QuadChannelOutput
+	</p>
+	<h3>Notes</h3>
+	<p>Normally, this object is used with two Audio Shields, which
+		are controlled separately by a pair of "sgtl5000" objects.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputI2SQuad">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputI2SHex">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 6 channel 16 bit audio, using I2S master mode.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Channel #1</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Channel #2</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Channel #3</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Channel #4</td></tr>
+		<tr class=odd><td align=center>In 4</td><td>Channel #5</td></tr>
+		<tr class=odd><td align=center>In 5</td><td>Channel #6</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 6 input ports to the I2S hardware.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>7</td><td>TX (ch 1+2)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>32</td><td>TX (ch 3+4)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>9</td><td>TX (ch 5+6)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<h3>Notes</h3>
+	<p>Teensy 4.0 &amp; 4.1's I2S port has a total of 5 data pins
+		which may each transmit or receive stereo digital audio.  This
+		6 channel output may be used together with the I2S stereo or
+		quad channel I2S input, but may not be combined with others
+		which use the same physical pins.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputI2SHex">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputI2SOct">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 8 channel 16 bit audio, using I2S master mode.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Channel #1</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Channel #2</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Channel #3</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Channel #4</td></tr>
+		<tr class=odd><td align=center>In 4</td><td>Channel #5</td></tr>
+		<tr class=odd><td align=center>In 5</td><td>Channel #6</td></tr>
+		<tr class=odd><td align=center>In 6</td><td>Channel #7</td></tr>
+		<tr class=odd><td align=center>In 7</td><td>Channel #8</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 8 input ports to the I2S hardware.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>21</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>7</td><td>TX (ch 1+2)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>32</td><td>TX (ch 3+4)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>9</td><td>TX (ch 5+6)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>6</td><td>TX (ch 7+8)</td><td>Output</td></tr>
+		<tr class=odd><td align=center>20</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<h3>Notes</h3>
+	<p>Teensy 4.0 &amp; 4.1's I2S port has a total of 5 data pins
+		which may each transmit or receive stereo digital audio.  This
+		8 channel output may be used together with the I2S stereo
+		input, but may not be combined with others
+		which use the same physical pins.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputI2SOct">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+<script type="text/x-red" data-help-name="AudioOutputI2S2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio to an I2S device, using I2S master mode, on the I2S2 port.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports to the I2S hardware.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "master" mode, where Teensy creates
+		all 3 clock signals and controls all data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>4</td><td>BCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>33</td><td>MCLK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>2</td><td>TX</td><td>Output</td></tr>
+		<tr class=odd><td align=center>3</td><td>LRCLK</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<h3>Notes</h3>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputI2S2">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputSPDIF">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio as Digital S/PDIF by use of the I2S port.</p>
+	<p align=center><img src="img/spdif_proto.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports S/PDIF encoded digital
+		audio on pin 22 (Teensy 3.x) or pin 7 (Teensy 4.x).</p>
+	<h3>Hardware</h3>
+	<p>The S/PDIF output signal can be used to drive an optical TOSLINK
+		cable, or a standard (usually orange) RCA jack.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>3.x Pin</th><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>22</td><td align=center>7</td><td>S/PDIF</td><td>Output</td></tr>
+	</table>
+	<p>For optical TOSLINK output, this
+		<a href="https://www.oshpark.com/shared_projects/KcDBKHta" target="_blank">OSH Park board</a>
+		can be used with the inexpensive Everlight PLT133/T6A connector, available
+		at Digikey, 1080-1434-ND.
+		</p>
+	<h3>Examples</h3>
+	<p>The AudioOutputSPDIF object can be used in place of the AudioOutputI2S object,
+	<p>used in nearly all the examples.  The WavFilePlayer shows how to substitute
+		output objects for different hardware types.
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; WavFilePlayer
+	</p>
+	<h3>Credits</h3>
+	<p><a href="https://github.com/FrankBoesing" target="_blank">Frank Boesing</a>
+		developed the AudioOutputSPDIF code.  The original
+		<a href="https://forum.pjrc.com/threads/28639-S-pdif" target="_blank">forum disussion</a>
+		included valuable input and code from "kpc".
+	<h3>Notes</h3>
+	<p>S/PDIF output uses the I2S hardware.  This object can not be used
+		together with any of the I2S objects, because it requires the I2S
+		hardware with different internal settings.</p>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputSPDIF">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputSPDIF2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio as Digital S/PDIF by use of the I2S2 port.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports S/PDIF encoded digital
+		audio on pin 2 (Teensy 4.x).</p>
+	<h3>Hardware</h3>
+	<p>The S/PDIF output signal can be used to drive an optical TOSLINK
+		cable, or a standard (usually orange) RCA jack.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>2</td><td>S/PDIF</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<p>The AudioOutputSPDIF object can be used in place of the AudioOutputI2S object,
+	<p>used in nearly all the examples.  The WavFilePlayer shows how to substitute
+		output objects for different hardware types.
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; WavFilePlayer
+	</p>
+	<h3>Credits</h3>
+	<p><a href="https://github.com/FrankBoesing" target="_blank">Frank Boesing</a>
+		developed the AudioOutputSPDIF code.  The original
+		<a href="https://forum.pjrc.com/threads/28639-S-pdif" target="_blank">forum disussion</a>
+		included valuable input and code from "kpc".
+	<h3>Notes</h3>
+	<p>S/PDIF output uses the I2S2 hardware.  This object can not be used
+		together with any of the I2S2 objects, because it requires the I2S2
+		hardware with different internal settings.</p>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputSPDIF2">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputSPDIF3">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio as Digital S/PDIF by use of the native S/PDIF port.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports S/PDIF encoded digital
+		audio on pin 14 (Teensy 4.x).</p>
+	<h3>Hardware</h3>
+	<p>The S/PDIF output signal can be used to drive an optical TOSLINK
+		cable, or a standard (usually orange) RCA jack.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>14</td><td>S/PDIF</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<p>The AudioOutputSPDIF object can be used in place of the AudioOutputI2S object,
+	<p>used in nearly all the examples.  The WavFilePlayer shows how to substitute
+		output objects for different hardware types.
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; WavFilePlayer
+	</p>
+	<h3>Credits</h3>
+	<p><a href="https://github.com/FrankBoesing" target="_blank">Frank Boesing</a>
+		developed the AudioOutputSPDIF3 code.
+	<h3>Notes</h3>
+	<p>Native S/PDIF hardware is used, which is more efficient that use of I2S ports.</p>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputSPDIF3">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputPT8211">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio to a low-cost PT8211 DAC chip.  4X oversampling
+		and filtering are automatically used to improve output quality.</p>
+	<p align=center><img src="img/pt8211.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports to a PT8211 chip.  4X
+		oversampling and filtering is automatically used to improve quality.</p>
+	<h3>Hardware</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>3.x Pin</th><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>22</td><td align=center>7</td><td>DIN</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>FS</td><td>Output</td></tr>
+	</table>
+	<p>More information can be found in the PT8211 datasheet.
+		</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PT8211Sine
+	</p>
+	<h3>Credits</h3>
+	<p>Frank Boesing and Benjamin developed this PT8211 object.  Details can be
+		found on this
+		<a href="https://forum.pjrc.com/threads/29284-Dual-channel-16bit-dac-PT8211/page3" target="_blank">forum disussion</a>.
+	<h3>Notes</h3>
+	<p>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputPT8211">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputPT8211_2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio to a low-cost PT8211 DAC chip, using the I2S2 port.  4X oversampling
+		and filtering are automatically used to improve output quality.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports to a PT8211 chip.  4X
+		oversampling and filtering is automatically used to improve quality.</p>
+	<h3>Hardware</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>4</td><td>BCK</td><td>Output</td></tr>
+		<tr class=odd><td align=center>2</td><td>DIN</td><td>Output</td></tr>
+		<tr class=odd><td align=center>3</td><td>FS</td><td>Output</td></tr>
+	</table>
+	<p>More information can be found in the PT8211 datasheet.
+		</p>
+	<h3>Examples</h3>
+	<h3>Credits</h3>
+	<p>Frank Boesing and Benjamin developed this PT8211 object.  Details can be
+		found on this
+		<a href="https://forum.pjrc.com/threads/29284-Dual-channel-16bit-dac-PT8211/page3" target="_blank">forum disussion</a>.
+	<h3>Notes</h3>
+	<p>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputPT8211_2">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputAnalog">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 12 bit audio using Teensy's built-in digital to analog converter.</p>
+	<p align=center><img src="img/dac_speaker.jpg"><br>
+	<small><a href="http://www.pjrc.com/store/prop_shield.html" target="_blank_">Prop Shield with 4&ohm; Speaker</a></small></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Audio Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>analogReference</span>(ref);</p>
+	<p class=desc>Configure output voltage range:<br>
+	<span class=literal>INTERNAL</span> selects 1.2 volt peak-to-peak output.<br>
+	<span class=literal>EXTERNAL</span> selects 3.3 volt peak-to-peak output.
+	</p>
+	<h3>Hardware</h3>
+	<p align=center><img src="img/dacpin.jpg"></p>
+	<p>Signal range default is 0 to 1.2V</p>
+	<p>The output voltage has DC level.  Some applications require a DC-blocking capacitor.  If unsure, a 10&micro;F is usually a safe value to use.  If an aluminum or tantalum capacitor is used, the positive terminal should connect to Teensy's DAC pin.</p>
+	<p>The DAC pin is used with the
+	<a href="http://www.pjrc.com/store/prop_shield.html" target="_blank_">Prop Shield</a>
+	to drive speakers.</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughMono
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; SamplePlayer
+	</p>
+	<p class=exam><a href="https://github.com/PaulStoffregen/TouchGuitar" target="_blank">TouchGuitar</a>
+	</p>
+	<p class=exam><a href="https://community.arm.com/groups/embedded/blog/2014/05/23/led-video-panel-at-maker-faire-2014" target="_blank">LED Video Board</a>
+	</p>
+	<p class=exam>File &gt; Examples &gt; OctoWS2811 &gt; VideoSDcard
+	</p>
+	<p class=exam>File &gt; Examples &gt; SerialFlash &gt; MP3Player
+	</p>
+	<h3>Notes</h3>
+	<p>The output rate is 44.1 kHz (no oversampling).  Ultrasonic noise present if
+		not filtered.  This may not
+		be an issue for many uses, but care should be used if amplified and driven
+		to high power tweeters.</p>
+	<p>When using 3.3V output, the power supply is used for the analog reference.  Noise
+		present on the 3.3V power can couple to the DAC output signal.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputAnalog">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputAnalogStereo">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 12 bit stereo audio using Teensy 3.5 or 3.6 built-in digital to analog converters.</p>
+	<!--<p align=center><img src="img/dac_speaker.jpg"><br>
+	<small><a href="http://www.pjrc.com/store/prop_shield.html" target="_blank_">Prop Shield with 4&ohm; Speaker</a></small></p>-->
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Audio Channel (Left)</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Audio Channel (Right)</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>analogReference</span>(ref);</p>
+	<p class=desc>Configure output voltage range:<br>
+	<span class=literal>INTERNAL</span> selects 1.2 volt peak-to-peak output.<br>
+	<span class=literal>EXTERNAL</span> selects 3.3 volt peak-to-peak output.
+	</p>
+	<h3>Hardware</h3>
+	<p align=center><img src="img/dacpins.png"></p>
+	<p>Signal range default is 0 to 1.2V</p>
+	<p>The output voltage has DC level.  Some applications require a DC-blocking capacitor.  If unsure, a 10&micro;F is usually a safe value to use.  If an aluminum or tantalum capacitor is used, the positive terminal should connect to Teensy's DAC pin.</p>
+	<p>The DAC pin is used with the
+	<a href="http://www.pjrc.com/store/prop_shield.html" target="_blank_">Prop Shield</a>
+	to drive speakers.</p>
+	<h3>Examples</h3>
+	<!--<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughMono
+	</p>
+	<p class=exam>File &gt; Examples &gt; SerialFlash &gt; MP3Player
+	</p>-->
+	<h3>Notes</h3>
+	<p>The output rate is 44.1 kHz (no oversampling).  Ultrasonic noise present if
+		not filtered.  This may not
+		be an issue for many uses, but care should be used if amplified and driven
+		to high power tweeters.</p>
+	<p>When using 3.3V output, the power supply is used for the analog reference.  Noise
+		present on the 3.3V power can couple to the DAC output signal.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputAnalogStereo">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputPWM">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit audio using Teensy 3's PWM pins.  Two pins are
+		used for coarse and fine pulses, to be combined by scaled
+		resistors.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<!--<li>Teensy 4.0
+	<li>Teensy 4.1-->
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Audio Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from the its input port to the PWM pins.</p>
+	<h3>Hardware</h3>
+	<p>The following circuit is recommended.</p>
+	<p align=center><img src="img/pwmdualcircuit.jpg"></p>
+	<p>Signal range is approx 1.55 Vp-p.</p>
+	<p>These resistor values assume approx 20 ohms output impedance
+		on the digital pins.  The 127K resistor may be adjusted or
+		trimmed for variation in output drive and tolerance on the
+		475 ohm resistor.</p>
+	<p>A plastic film (Polypropylene, Polyethylene, Polyester, etc) or
+		C0G/NPO ceramic capacitor should be used for filtering.  Low
+		quality ceramic (X7R, Y5V, Z5U, etc) can cause signal distortion.</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughMono
+	</p>
+	<h3>Notes</h3>
+	<p>This object only works properly when Tools &gt; CPU_Speed is set to
+		48 or 96 MHz.  Other speeds aren't supported and will likely fail
+		in strange ways.</p>
+	<p>The PWM carrier frequency is 88.2 kHz.  The suggested circuit
+		will only slightly filter the carrier.  Extra filtering will be
+		required for a clean signal without the ultrasonic PWM carrier.
+		</p>
+	<p>Analog signals created by filtering PWM waveforms use the digital
+		power supply as their reference voltage.  Any noise on the digital
+		power line can directly couple to the output signal.  The built-in DAC or
+		<a href="http://www.pjrc.com/store/teensy3_audio.html" target="_blank">audio shield</a>
+		should be used when higher quality signals are needed.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputPWM">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputMQS">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio using Medium Quality Sound pulses, usually better than PWM,
+		but not as good as a proper DAC or the audio shield.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports to generate output pulses.</p>
+	<h3>Hardware</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>12</td><td>Left</td><td>Output</td></tr>
+		<tr class=odd><td align=center>10</td><td>Right</td><td>Output</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<h3>Notes</h3>
+	<p>TODO: can this really be used together with other inputs and outputs?</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputMQS">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputI2Sslave">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit 16 bit stereo audio to an I2S device using I2S slave mode
+		(where the DAC or codec chip, not Teensy, controls audio timing).</p>
+	<p><span style="color:red">This input is incompatible with most other inputs and outputs</span>
+		which run at a speed controlled by Teensy's internal sample rate.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 2 input ports to the I2S hardware.</p>
+	<h3>Hardware</h3>
+	<p>The I2S signals are used in "slave" mode, where the I2S device controls
+		data timing.</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>3.x Pin</th><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Input</td></tr>
+		<tr class=odd><td align=center>22</td><td align=center>7</td><td>TX</td><td>Output</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>LRCLK</td><td>Input</td></tr>
+	</table>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; WM8731MikroSine
+	</p>
+	<h3>Notes</h3>
+	<p>Slave mode I2S <b>should not used in the same project as ADC, DAC and
+		PWM</b> signals.  Differences in timing between the I2S device and
+		Teensy's clock can cause occasional audio glitches when I2S slave mode
+		is used together with other input or output objects based on Teensy's
+		timing.</p>
+	<p>Only one I2S input and one I2S output object may be used.  Master
+		and slave modes may not be mixed (both must be of the same type).
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputI2Sslave">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputTDM">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit a 256 bit Time Division Multiplexed frame containing
+		many audio channels.</p>
+	<p align=center><img src="img/tdm.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Bits 0 to 15</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Bits 16 to 31</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Bits 32 to 47</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Bits 48 to 63</td></tr>
+		<tr class=odd><td align=center>In 4</td><td>Bits 64 to 79</td></tr>
+		<tr class=odd><td align=center>In 5</td><td>Bits 80 to 95</td></tr>
+		<tr class=odd><td align=center>In 6</td><td>Bits 96 to 111</td></tr>
+		<tr class=odd><td align=center>In 7</td><td>Bits 112 to 127</td></tr>
+		<tr class=odd><td align=center>In 8</td><td>Bits 128 to 143</td></tr>
+		<tr class=odd><td align=center>In 9</td><td>Bits 144 to 159</td></tr>
+		<tr class=odd><td align=center>In 10</td><td>Bits 160 to 175</td></tr>
+		<tr class=odd><td align=center>In 11</td><td>Bits 176 to 191</td></tr>
+		<tr class=odd><td align=center>In 12</td><td>Bits 192 to 207</td></tr>
+		<tr class=odd><td align=center>In 13</td><td>Bits 208 to 223</td></tr>
+		<tr class=odd><td align=center>In 14</td><td>Bits 224 to 239</td></tr>
+		<tr class=odd><td align=center>In 15</td><td>Bits 240 to 255</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 16 input ports to the TDM hardware.</p>
+	<h3>Hardware</h3>
+	<p>TDM has been tested with this <a href="https://oshpark.com/shared_projects/2Yj6rFaW">
+		CS42448 Board for Teensy 3.x</a> and this
+		<a href="https://oshpark.com/shared_projects/gVFy0fWQ">
+		CS42448 Board for Teensy 4.x</a> and this
+		<a href="https://oshpark.com/shared_projects/O7iqdcLr">
+		ADAU1966A Board for Teensy 4.x</a>, and an
+		<a href="https://forum.pjrc.com/threads/72479?p=327541&viewfull=1#post327541">
+		inexpensive CS42448 breakout board</a>.
+		</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>T3.x<br>Pin</th><th>T4.x<br>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>9</td><td align=center>21</td><td>BCLK</td><td>Output, 11.3 MHz</td></tr>
+		<tr class=odd><td align=center>11</td><td align=center>23</td><td>MCLK</td><td>Output, 22.6 MHz</td></tr>
+		<tr class=odd><td align=center>22</td><td align=center>7</td><td>TX</td><td>Output, 11.3 Mbit/sec</td></tr>
+		<tr class=odd><td align=center>23</td><td align=center>20</td><td>WS</td><td>Output</td></tr>
+	</table>
+	<p>Audio from
+		master mode TDM may be used in the same project as ADC, DAC and
+		PWM signals, because all remain in sync to Teensy's timing</p>
+	<h3>Examples</h3>
+	<p><a href="https://www.youtube.com/watch?v=LOnEv4EDYsk">Video Demo</a> (YouTube)
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; WaveformsTDM16</p>
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughTDM16</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Only one TDM input and one TDM output object may be used.  The
+		I2S hardware is used by TDM, so TDM objects may not be used
+		together with I2S, SPDIF or PT8211.</p>
+	<p>When used with TDM devices which receive 32 bit audio, the
+		even numbered channels are used for the top 16 bits.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputTDM">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputTDM2">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit a 256 bit Time Division Multiplexed frame containing
+		many audio channels, using the I2S2 port.</p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Bits 0 to 15</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Bits 16 to 31</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Bits 32 to 47</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Bits 48 to 63</td></tr>
+		<tr class=odd><td align=center>In 4</td><td>Bits 64 to 79</td></tr>
+		<tr class=odd><td align=center>In 5</td><td>Bits 80 to 95</td></tr>
+		<tr class=odd><td align=center>In 6</td><td>Bits 96 to 111</td></tr>
+		<tr class=odd><td align=center>In 7</td><td>Bits 112 to 127</td></tr>
+		<tr class=odd><td align=center>In 8</td><td>Bits 128 to 143</td></tr>
+		<tr class=odd><td align=center>In 9</td><td>Bits 144 to 159</td></tr>
+		<tr class=odd><td align=center>In 10</td><td>Bits 160 to 175</td></tr>
+		<tr class=odd><td align=center>In 11</td><td>Bits 176 to 191</td></tr>
+		<tr class=odd><td align=center>In 12</td><td>Bits 192 to 207</td></tr>
+		<tr class=odd><td align=center>In 13</td><td>Bits 208 to 223</td></tr>
+		<tr class=odd><td align=center>In 14</td><td>Bits 224 to 239</td></tr>
+		<tr class=odd><td align=center>In 15</td><td>Bits 240 to 255</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 16 input ports to the TDM hardware.</p>
+	<h3>Hardware</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Teensy<br>4.x Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>4</td><td>BCLK</td><td>Output, 11.3 MHz</td></tr>
+		<tr class=odd><td align=center>33</td><td>MCLK</td><td>Output, 22.6 MHz</td></tr>
+		<tr class=odd><td align=center>2</td><td>TX</td><td>Output, 11.3 Mbit/sec</td></tr>
+		<tr class=odd><td align=center>3</td><td>WS</td><td>Output</td></tr>
+	</table>
+	<!--<h3>Examples</h3>-->
+	<h3>Notes</h3>
+	<p>When used with TDM devices which receive 32 bit audio, the
+		even numbered channels are used for the top 16 bits.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputTDM2">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputADAT">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Transmit ADAT TOSLINK Optical Output</p>
+	<p align=center><img src="img/adat.jpg"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<!--<li>Teensy 4.0
+	<li>Teensy 4.1-->
+	</ul>
+	<p>ADAT output for Teensy 4.0 is discussed on
+	<a href="https://forum.pjrc.com/threads/60914?p=239824&viewfull=1#post239824">this forum thread</a>.</p>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Channel 1</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Channel 2</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Channel 3</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Channel 4</td></tr>
+		<tr class=odd><td align=center>In 4</td><td>Channel 5</td></tr>
+		<tr class=odd><td align=center>In 5</td><td>Channel 6</td></tr>
+		<tr class=odd><td align=center>In 6</td><td>Channel 7</td></tr>
+		<tr class=odd><td align=center>In 7</td><td>Channel 8</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams data from its 8 input ports to the TOSLINK output.</p>
+	<h3>Hardware</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Pin</th><th>Signal</th><th>Direction</th></tr>
+		<tr class=odd><td align=center>22</td><td>TX</td><td>TOSLINK Signal</td></tr>
+	</table>
+	<p>For optical TOSLINK output, this
+		<a href="https://www.oshpark.com/shared_projects/KcDBKHta" target="_blank">OSH Park board</a>
+		can be used with the inexpensive Everlight PLT133/T6A connector, available
+		at Digikey, 1080-1434-ND.
+		</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; ADAT_DrumSamplePlayer
+	</p>
+	<h3>Notes</h3>
+	<p>ADAT output was contributed by Ernstjan Freriks.  See <a href="https://forum.pjrc.com/threads/28639-S-pdif?p=159530&viewfull=1#post159530">this forum thread</a> for details.</p>
+	<p>A <a href="https://www.youtube.com/watch?v=e5ov3q02zxo">Youtube video</a>
+		also demonstrates how it works.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputADAT">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioOutputUSB">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Send stereo audio to a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_out.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 3.2
+	<li>Teensy 3.5
+	<li>Teensy 3.6
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Channel</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Channel</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams from it's 2 input ports to the USB.</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; WavFilePlayerUSB</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+	<p>A known problem exists with USB audio from Macintosh computers.
+		An imperfect <a href="https://forum.pjrc.com/threads/34855-Distorted-audio-when-using-USB-input-on-Teensy-3-1?p=110392&viewfull=1#post110392">workaround
+		can be enabled by editing usb_audio.cpp</a>.
+		Find and uncomment "#define MACOSX_ADAPTIVE_LIMIT".</p>
+</script>
+<script type="text/x-red" data-template-name="AudioOutputUSB">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAmplifier">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Amplify or attenuate a signal, or switch it on/off.
+		</p>
+	<p align=center><img src="img/ampschematics.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Input signal</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Amplified/Attn. Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>gain</span>(level);</p>
+	<p class=desc>Adjust the amplification or attenuation.
+		"level" may be any floating point number from 0 to 32767.0.
+		1.0 passes the signal through directly.  Level of 0 shuts the channel
+		off completely.  Between 0 to 1.0 attenuates the signal, and above
+		1.0 amplifies it.  Negative numbers may also be used, to invert the
+		signal.
+	</p>
+	<!--<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; SamplePlayer
+	</p>-->
+	<h3>Notes</h3>
+	<p>Gain of 0 and 1.0 are handled efficiently as special cases.  Zero
+		discards data without processing.  1.0 passes data directly, with
+		minimal overhead</p>
+	<p>Signal clipping can occur when any channel has gain greater than 1.0</p>
+</script>
+<script type="text/x-red" data-template-name="AudioAmplifier">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioMixer4">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Combine up to 4 audio signals together, each with adjustable gain.
+		All channels support signal attenuation or amplification.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Input signal #1</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Input signal #2</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Input signal #3</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Input signal #4</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sum of all inputs</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>gain</span>(channel, level);</p>
+	<p class=desc>Adjust the amplification or attenuation.  "channel" must
+		be 0 to 3.  "level" may be any floating point number from 0 to 32767.0.
+		1.0 passes the signal through directly.  Level of 0 shuts the channel
+		off completely.  Between 0 to 1.0 attenuates the signal, and above
+		1.0 amplifies it.  Negative numbers may also be used, to invert the
+		signal.  All 4 channels have separate gain settings.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; SamplePlayer
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; PlaySynthMusic
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; SpectrumAnalyzerBasic
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; DialTone_Serial
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; MemoryAndCpuUsage
+	</p>
+	<h3>Notes</h3>
+	<p>Signal clipping can occur when any channel has gain greater than 1.0,
+		or when multiple signals add together to greater than 1.0.</p>
+	<p>More than 4 channels may be combined by connecting multiple mixers
+		in tandem.  For example, a 16 channel mixer may be built using 5
+		mixers, where the fifth mixer combines the outputs of the first 4.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioMixer4">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioPlayMemory">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Play a short sound clip, stored directly in memory.
+		Data files are created with the
+		<a href="https://github.com/PaulStoffregen/Audio/tree/master/extras/wav2sketch" target="_blank">wav2sketch program</a>,
+		and copied to the sketch folder to become part of your sketch.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sound Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>play</span>(data);</p>
+	<p class=desc>Begin playing a sound clip.  If already playing, the
+		currently playing clip is stopped and this new data begins
+		playing from the beginning.
+	</p>
+	<p class=func><span class=keyword>stop</span>();</p>
+	<p class=desc>Stop playing.  If not playing, this function has no effect.
+	</p>
+	<p class=func><span class=keyword>isPlaying</span>();</p>
+	<p class=desc>Return true (non-zero) if playing, or false (zero)
+		when not playing.
+	</p>
+	<p class=func><span class=keyword>positionMillis</span>();</p>
+	<p class=desc>While playing, return the current time offset, in
+		milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<p class=func><span class=keyword>lengthMillis</span>();</p>
+	<p class=desc>Return the total length of the current sound clip,
+		in milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; SamplePlayer
+	</p>
+	<h3>Notes</h3>
+	<p><a href="https://forum.pjrc.com/threads/42401-Instructions-or-tutorials-for-using-wav2sketch?p=135069&viewfull=1#post135069">Step by step instructions for wav2sketch</a>
+		running in Terminal on Macintosh.</p>
+	<p><a href="https://www.pjrc.com/teensy/td_libs_AudioPlayMemory.html">Old documentation about wav2sketch</a>
+		is still available, including details about the data format.</p>
+	<p>TODO: supported sample rates: 11.025, 22.05, 44.1</p>
+	<p>TODO: ulaw vs uncompressed encoding</p>
+	<p>Polyphonic playback can be built by creating multiple
+		objects, with their output combined by mixers.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioPlayMemory">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioPlaySdWav">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Play a WAV file, stored on a SD card.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Left Channel Output</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Right Channel Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>play</span>(filename);</p>
+	<p class=desc>Begin playing a WAV file.  If a file is already playing,
+		it is stopped and this file starts playing from the beginning.
+	</p>
+	<p class=func><span class=keyword>stop</span>();</p>
+	<p class=desc>Stop playing.  If not playing, this function has no effect.
+	</p>
+	<p class=func><span class=keyword>isPlaying</span>();</p>
+	<p class=desc>Return true (non-zero) if playing, or false (zero)
+		when not playing.  See the note below about delayed start.
+	</p>
+	<p class=func><span class=keyword>positionMillis</span>();</p>
+	<p class=desc>While playing, return the current time offset, in
+		milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<p class=func><span class=keyword>lengthMillis</span>();</p>
+	<p class=desc>Return the total length of the current sound clip,
+		in milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; WavFilePlayer
+	</p>
+	<h3>Notes</h3>
+	<p>Only 16 bit PCM, 44100 Hz WAV files are supported.  When mono
+		files are played, both output ports transmit a copy of the
+		single sound.  Of course, stereo WAV files play with the left
+		channel on port 0 and the right channel on port 1.
+	</p>
+	<p>A brief delay after calling play() will usually occur before
+		isPlaying() returns true and positionMillis() returns valid
+		time offset.  WAV files have a header at the beginning of the
+		file, which the audio library must read and parse before
+		playing can begin.
+	</p>
+	<p>While playing, the audio library accesses the SD card automatically.
+		If card access is required, you must
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">use AudioNoInterrupts()</a>
+		to prevent the library from accessing the SD card while you use it.
+		Disabling the audio library interrupt for too long may cause audible
+		dropouts or glitches.
+	</p>
+	<p>An experimental SD library optimization exists, which can remove these
+		SD library restrictions.  It also allows reliable playback of more
+		files at the same time.  To enable this special code, find and edit
+		the SD_t3.h file within your Arduino folder.  See the comments within
+		that file for details.
+	</p>
+
+</script>
+<script type="text/x-red" data-template-name="AudioPlaySdWav">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioPlaySdRaw">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Play a RAW data file, stored on a SD card.  RAW format is simpler
+		than WAV and begins playing immediately, without parsing WAV file
+		header info.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sound Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>play</span>(filename);</p>
+	<p class=desc>Begin playing a RAW data file.  If a file is already playing,
+		it is stopped and this file starts playing from the beginning.
+	</p>
+	<p class=func><span class=keyword>stop</span>();</p>
+	<p class=desc>Stop playing.  If not playing, this function has no effect.
+	</p>
+	<p class=func><span class=keyword>isPlaying</span>();</p>
+	<p class=desc>Return true (non-zero) if playing, or false (zero)
+		when not playing.
+	</p>
+	<p class=func><span class=keyword>positionMillis</span>();</p>
+	<p class=desc>While playing, return the current time offset, in
+		milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<p class=func><span class=keyword>lengthMillis</span>();</p>
+	<p class=desc>Return the total length of the current sound clip,
+		in milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Recorder
+	</p>
+	<h3>Notes</h3>
+	<p>The data file must be RAW 16 bit signed integers in LSB-first format.
+	</p>
+	<p>While playing, the audio library accesses the SD card automatically.
+		If card access is required, you must
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		to prevent the library from accessing the SD card while you use it.
+		Disabling the audio library interrupt for too long may cause audible
+		dropouts or glitches.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioPlaySdRaw">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioPlaySerialflashRaw">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Play a RAW data file, stored on a Serial Flash chip.  These chips
+		are far more efficient than SD cards, allowing many files to be
+		played simultaneously by copies of this object.
+		</p>
+	<p align=center><img src="img/w25q128fv.jpg"><br><small>W25Q128FV Serial Flash</small></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sound Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>play</span>(filename);</p>
+	<p class=desc>Begin playing a RAW data file.  If a file is already playing,
+		it is stopped and this file starts playing from the beginning.
+	</p>
+	<p class=func><span class=keyword>stop</span>();</p>
+	<p class=desc>Stop playing.  If not playing, this function has no effect.
+	</p>
+	<p class=func><span class=keyword>isPlaying</span>();</p>
+	<p class=desc>Return true (non-zero) if playing, or false (zero)
+		when not playing.
+	</p>
+	<p class=func><span class=keyword>positionMillis</span>();</p>
+	<p class=desc>While playing, return the current time offset, in
+		milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<p class=func><span class=keyword>lengthMillis</span>();</p>
+	<p class=desc>Return the total length of the current sound clip,
+		in milliseconds.  When not playing, the return from this function
+		is undefined.
+	</p>
+	<h3>Examples</h3>
+	<!--
+<p class=exam>File &gt; Examples &gt; Audio &gt; Recorder
+-->
+	<p class=exam>TODO: play example needed....
+	</p>
+	<p class=exam>File &gt; Examples &gt; SerialFlash &gt; CopyFromSD
+	</p>
+	<h3>Notes</h3>
+	<p>The data file must be RAW 16 bit signed integers in LSB-first format.
+	</p>
+	<p>The <a href="https://github.com/PaulStoffregen/SerialFlash" target="_blank">SerialFlash library</a>
+		is used to access the flash chip.  You can also use SerialFlash's functions
+		to access the stored files, or add data to the flash chip.
+	</p>
+	<p>File names are case sensitive with SerialFlash.  If your sound does
+		not play, use <b>File &gt; Examples &gt; SerialFlash &gt; ListFiles</b> to
+		check the exact file names stored in the flash memory chip.
+</script>
+<script type="text/x-red" data-template-name="AudioPlaySerialflashRaw">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioPlayQueue">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Play audio data provided by the Arduino sketch.  This object provides
+		functions to allow the sketch code to push data into the audio system.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sound Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>setMaxBuffers</span>(uint8);</p>
+	<p class=desc>Set the maximum buffer block count for the queue to limit its size - by default 32 blocks are used on Teensy 3.x
+	  and 80 on Teensy 4.x - this allows the value to be reduced so that the queue cannot get too far ahead, nor use up lots of
+	  audio blocks you might want for other purposes.  The minimum number of buffer blocks is 2.
+	</p>
+	<p class=func><span class=keyword>play</span>(int16);</p>
+	<p class=desc>add a single sample to the queue - no need to use getBuffer() or playBuffer() as this
+	  method does the necessary handling.  
+	  		</p>	  
+	  <p class=desc>If the behaviour is set to ORIGINAL then this method may block waiting for a spare buffer if the queue is full.
+	  		</p>	  
+	  <p class=desc>If the behaviour is set to NON_STALLING then this method may return a non-zero value: 
+	  in this case the call must be re-tried, passing in the original sample value.
+	</p>
+	<p class=func><span class=keyword>play</span>(int16[], length);</p>
+	<p class=desc>add multiple samples to the queue - no need to use getBuffer() or playBuffer() as this
+	  method does the necessary handling.  
+	  The length should be the number of samples in the array, which need not be a multiple of AUDIO_BLOCK_SAMPLES.
+	  <p class=desc>If the behaviour is set to ORIGINAL then this method may block waiting for a spare buffer if the queue is full.
+		</p>	  
+	  <p class=desc>If the behaviour is set to NON_STALLING then this method will return the number of samples unused (due to unavailable
+	  audio blocks or queue space): if non-zero then the call must be re-tried, with an updated array pointer and length.
+		</p>
+	</p>
+	<p class=func><span class=keyword>getBuffer</span>();</p>
+	<p class=desc>Returns a pointer to an array of AUDIO_BLOCK_SAMPLES (usually 128) int16.  This buffer
+	  is within the audio library memory pool, providing the most efficient
+	  way to input data to the audio system.  The buffer is likely to be
+	  populated by previously used data, so the entire AUDIO_BLOCK_SAMPLES samples should be
+	  written before calling playBuffer().  Only a single buffer is allocated at any one time: 
+	  repeated calls to getBuffer() without calling playBuffer() will yield the same address.
+	<p class=desc>
+	  If the behaviour is set to ORIGINAL then this function will wait (possibly forever) for memory to become available. 
+	  If set to NON_STALLING then function may return NULL if no memory is available.			
+		</p>
+	</p>
+	<p>You may find it easier to use the play() methods unless performance is crucial.
+	</p>
+	<p class=func><span class=keyword>playBuffer</span>();</p>
+	<p class=desc>Transmit the buffer previously obtained from getBuffer().  If you use the play() methods you should not use this.
+	</p>
+	<p class=desc>
+	  If the behaviour is set to ORIGINAL then this function will wait (up to 2.9ms) for a queue space to become available. 
+	  If set to NON_STALLING then function may return a non-zero value if no queue space is free: 
+	  in this case the call must be re-tried later, before any further call to getBuffer() is made.
+		</p>
+	<p class=func><span class=keyword>setBehaviour</span>(value);</p>
+	<p class=desc>Value should be AudioPlayQueue::ORIGINAL to preserve the original behaviour of getBuffer() and playBuffer(), 
+		which can both stall until audio blocks or queue entries become available, with consequences for system performance.
+		Setting the value to AudioPlayQueue::NON_STALLING results in all the above functions returning promptly, but possibly
+		with a status indicating failure or a need to re-try. See the PlayQueueDemo example.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Queues &gt; PlayQueueDemo
+	</p>
+		<p><a href="http://community.arm.com/groups/embedded/blog/2014/05/23/led-video-panel-at-maker-faire-2014" target="_blank">4320 LED Video+Sound Project</a>
+		</p>
+	<!--
+<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>TODO: many caveats....</p>
+	<p>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioPlayQueue">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioRecordQueue">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Record audio data by sending to the Arduino sketch.  This object allows
+		sketch code to receive audio packets.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Sound To Access</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>();</p>
+	<p class=desc>Begin capturing incoming audio to the queue.  After calling
+		begin, readBuffer() and freeBuffer(), or clear() must be used frequently
+		to prevent the queue from filling up.
+	</p>
+	<p class=func><span class=keyword>available</span>();</p>
+	<p class=desc>Returns the number of audio packets available to read.
+	</p>
+	<p class=func><span class=keyword>readBuffer</span>();</p>
+	<p class=desc>Read a single audio packet.  A pointer to a 128 sample
+		array of 16 bit integers is returned.  NULL is returned if no packets
+		are available.
+	</p>
+	<p class=func><span class=keyword>freeBuffer</span>();</p>
+	<p class=desc>Release the memory from the previously read packet returned
+		from readBuffer().  Only a single packet at a time may be read, and
+		each packet must be freed with this function, to return the memory to
+		the audio library.
+	</p>
+	<p class=func><span class=keyword>clear</span>();</p>
+	<p class=desc>Discard all audio held in the queue.
+	</p>
+	<p class=func><span class=keyword>end</span>();</p>
+	<p class=desc>Stop capturing incoming audio into the queue.  Data already
+		captured remains in the queue and may be read with readBuffer().
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Recorder
+	</p>
+	<h3>Notes</h3>
+	<p>
+		Up to 52 packets may be queued by this object, which allows approximately
+		150 ms of audio to be held in the queue, to allow time for the Arduino
+		sketch to write data to media or do other high-latency tasks.
+
+The actual packets are taken
+		from the pool created by AudioMemory().
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioRecordQueue">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+<script type="text/x-red" data-help-name="AudioSynthWavetable">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Synthesize musical instruments using wavetable samples.
+		Sample data is extracted from SoundFont2 files.
+		</p>
+	<p align=center><a href="https://www.youtube.com/watch?v=5laaNHLhS98">YouTube Video Demo</a><br>
+		<a href="https://www.youtube.com/watch?v=5laaNHLhS98"><img border=0 src="img/wavetablevideo.jpg"></a>
+		</p>
+	<p><small>
+		Portland State University capstone project by
+		Ryan Mellmer, Nicholas Craig, Joshua Bucklin, Aida Keifer,
+		Jonathan Jensen, Yu Tang, &amp; Connor Delaplane.
+	</small></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+		<p>Note that "amplitude" is treated inconsistently within this object, 
+		and inconsistently with the general approach of the Audio library, 
+		which is to use values between 0.0 and 1.0
+		</p>
+	<p class=func><span class=keyword>setInstrument</span>(instrument);</p>
+	<p class=desc>Set sample set to instrument (reference to AudioSynthWavetable::instrument_data)
+	</p>
+	<p class=func><span class=keyword>amplitude</span>(volume);</p>
+	<p class=desc>Change amplitude. Volume is float in the range 0.0-1.0.
+	</p>
+	<p class=func><span class=keyword>setFrequency</span>(freq);</p>
+	<p class=desc>Set frequency of playing note (freq is float in Hz). Note that this
+	will not necessarily have the same sound as a note played at the given frequency, as
+	the sample is use is not changed.
+	</p>
+	<p class=func><span class=keyword>playFrequency</span>(freq, amplitude);</p>
+	<p class=desc>Play a note at a given frequency (float, Hz) and amplitude (integer, 0 - 127).
+	</p>
+	<p class=func><span class=keyword>playNote</span>(noteNumber, amplitude);</p>
+	<p class=desc>Play a note at a given MIDI note number (int, 0 - 127) and amplitude (integer, 0 - 127).
+	</p>
+	<p class=func><span class=keyword>stop</span>();</p>
+	<p class=desc>Stop playing a note. The sound will typically not stop immediately, but
+	decay away according to the release parameter of the wavetable. Use isPlaying()
+	to determine if the note has finished.
+	</p>
+	<p class=func><span class=keyword>isPlaying</span>();</p>
+	<p class=desc>Returns true if a note is playing.
+	</p>
+	<p class=func><span class=keyword>getEnvState</span>();</p>
+	<p class=desc>Return AudioSynthWavetable::envelopeStateEnum value giving current
+	state of the envelope generator. One of STATE_IDLE, STATE_DELAY, STATE_ATTACK, 
+	STATE_HOLD, STATE_DECAY, STATE_SUSTAIN, STATE_RELEASE 
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; Wavetable &gt; MidiSynth
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; Wavetable &gt; MidiSynthKeyboard
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; Wavetable &gt; MidiSynthLarge
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; Wavetable &gt; SimpleWavetable
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; Wavetable &gt; Zelda
+	</p>
+	<h3>Notes</h3>
+	<p></p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWavetable">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+<script type="text/x-red" data-help-name="AudioSynthSimpleDrum">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Generate a synthesised drum sound.  Also useful for laser pistol and bursting
+		bubble sound effects.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Drum Tone Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>noteOn</span>();</p>
+	<p class=desc>Trigger the drum.
+	</p>
+	<p class=func><span class=keyword>frequency</span>(frequency);</p>
+	<p class=desc>Set the base frequency of the drum.
+	</p>
+	<p class=func><span class=keyword>length</span>(milliseconds);</p>
+	<p class=desc>Set the duration of the envelope, in milliseconds.
+	</p>
+	<p class=func><span class=keyword>secondMix</span>(level);</p>
+	<p class=desc>Emulates a two-headed tom, by adding a second sine wave that is
+	harmonized a perfect fifth above
+	the base frequency.  Using this involves a slight CPU penalty.
+	</p>
+	<p class=func><span class=keyword>pitchMod</span>(depth);</p>
+	<p class=desc>Set the depth of envelope of the pitch, by a maximum of two octaves.
+	Default is 0.5, with no modulation.  Values above 0.5 cause the pitch to sweep
+	downwards, values lower than 0.5 cause the pitch to sweep upwards.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Synthesis &gt; SimpleDrum
+	</p>
+	<h3>Notes</h3>
+	<p></p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthSimpleDrum">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthKarplusStrong">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Synthesize a plucked string sound, such as a guitar string.
+		</p>
+	<p align=center><img src="img/touchguitar.jpg"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sound Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>noteOn</span>(frequency, velocity);</p>
+	<p class=desc>Begin a new string note.  Velocity can be from 0 to 1.0,
+		indicating how hard the string is plucked.
+	</p>
+	<p class=func><span class=keyword>noteOff</span>(velocity);</p>
+	<p class=desc>Stop the sound output.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Synthesis &gt; Guitar
+	</p>
+	<p class=exam><a href="https://github.com/PaulStoffregen/TouchGuitar" target="_blank">TouchGuitar</a>
+	</p>
+	<h3>Notes</h3>
+	<p></p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthKarplusStrong">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthWaveformSine">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create a sine wave signal</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sine Wave Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Set the amplitude, from 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Set the frequency, from 0 to 22000.  Very low values may
+		be used to create a LFO (Low Frequency Oscillator) for objects
+		with modulation signal inputs.
+	</p>
+	<p class=func><span class=keyword>phase</span>(angle);</p>
+	<p class=desc>
+		Cause the generated waveform to jump to a specific point within
+		its cycle.  Angle is from 0 to 360 degrees.  When multiple objects
+		are configured,
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used to guarantee all new settings take effect together.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; MemoryAndCpuUsage
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; DialTone_Serial
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; FFT
+	</p>
+	<h3>Notes</h3>
+	<p></p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWaveformSine">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthWaveformSineHires">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create a highly precise, low distortion sine wave signal.
+		Mainly useful for codec &amp; analog circuitry testing.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sine Wave, upper bits</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Sine Wave, lower bits</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Set the amplitude, from 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Set the frequency, from 0 to 22000.  Very low values may
+		be used to create a LFO (Low Frequency Oscillator) for objects
+		with modulation signal inputs.
+	</p>
+	<p class=func><span class=keyword>phase</span>(angle);</p>
+	<p class=desc>
+		Cause the generated waveform to jump to a specific point within
+		its cycle.  Angle is from 0 to 360 degrees.  When multiple objects
+		are configured,
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used to guarantee all new settings take effect together.
+	</p>
+	<h3>Notes</h3>
+	<p>An 11th order Taylor series approximation is used to generate
+		a very accurate sine wave.  At least the upper 25 bits are believe
+		to be perfect.  This is mainly intended for testing 24 bit codec chips!</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWaveformSineHires">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthWaveformSineModulated">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create a modulated sine wave, using any audio signal to continuously
+		modulate the sine wave frequency.  Note: limited modulation range,
+		use waveformMod for FM synthesis needing wide modulation range.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Modulation Signal</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Sine Wave Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Set the amplitude, from 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Set the center frequency, from 0 to 11000.  The output will
+		be this center frequency when the input modulation signal is zero.
+		Modulation input 1.0 causes the frequency to double, and input -1.0
+		causes zero Hz (DC) output.  For less modulation, attenuate the input
+		signal (perhaps with a mixer object) before it arrives here.
+	</p>
+	<p class=func><span class=keyword>phase</span>(angle);</p>
+	<p class=desc>
+		Cause the generated waveform to jump to a specific point within
+		its cycle.  Angle is from 0 to 360 degrees.  When multiple objects
+		are configured,
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used to guarantee all new settings take effect together.
+	</p>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>This modulated sine wave offers only limited range, and the control
+		input scales differently than "volt per octave" commonly used
+		with FM synthesis.  Use the newer AudioSynthWaveformModulated
+		(waveformMod) waveform when wide range is needed.  This simple
+		sine wave uses a very simple algorithm, written in the earliest
+		versions of the Teensy Audio Library.  The newer waveformMod
+		offers up to 12 octaves modulation with control input mapped
+		to modulation in the way commonly used by audio synthesis.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWaveformSineModulated">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthWaveform">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create a waveform: sine, sawtooth, square, triangle, pulse, random S&H or arbitrary.</p>
+	<p align=center><img src="img/waveforms.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Waveform Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>(waveform);</p>
+	<p class=desc>Configure the waveform type to create.
+	</p>
+	<p class=func><span class=keyword>begin</span>(level, frequency, waveform);</p>
+	<p class=desc>Output a waveform, and set the amplitude and frequency.
+	</p>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Change the frequency.
+	</p>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Change the amplitude.  Set to 0 to turn the signal off.
+	</p>
+	<p class=func><span class=keyword>offset</span>(level);</p>
+	<p class=desc>Add a DC offset, from -1.0 to +1.0.  Useful for generating
+		waveforms to use as control or modulation signals.
+	</p>
+	<p class=func><span class=keyword>phase</span>(angle);</p>
+	<p class=desc>
+		Cause the generated waveform to jump to a specific point within
+		its cycle.  Angle is from 0 to 360 degrees.  When multiple objects
+		are configured,
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used to guarantee all new settings take effect together.
+	</p>
+	<p class=func><span class=keyword>pulseWidth</span>(amount);</p>
+	<p class=desc>Change the width (duty cycle) of the pulse.</p>
+	<p class=func><span class=keyword>arbitraryWaveform</span>(array, maxFreq);</p>
+	<p class=desc>
+		Configure the waveform to be used with WAVEFORM_ARBITRARY.  Array
+		must be an array of 256 samples.  Currently, the data is used
+		without any filtering, which can cause aliasing with frequencies
+		above 172 Hz.  For higher frequency output, you must bandwidth
+		limit your waveform data.  Someday, "maxFreq" will be used to
+		do this automatically.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; Waveforms
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; PlaySynthMusic
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; pulseWidth
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; WM8731MikroSine
+	</p>
+	<h3>Notes</h3>
+	<p>Supported Waveforms:<br>
+		<ul>
+		<li><span class=literal>WAVEFORM_SINE</span></li>
+		<li><span class=literal>WAVEFORM_SAWTOOTH</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_SAWTOOTH</span></li>
+		<li><span class=literal>WAVEFORM_SAWTOOTH_REVERSE</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_SAWTOOTH_REVERSE</span></li>
+		<li><span class=literal>WAVEFORM_SQUARE</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_SQUARE</span></li>
+		<li><span class=literal>WAVEFORM_TRIANGLE</span></li>
+		<li><span class=literal>WAVEFORM_TRIANGLE_VARIABLE</span></li>
+		<li><span class=literal>WAVEFORM_ARBITRARY</span></li>
+		<li><span class=literal>WAVEFORM_PULSE</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_PULSE</span></li>
+		<li><span class=literal>WAVEFORM_SAMPLE_HOLD</span></li>
+		</ul>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWaveform">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthWaveformModulated">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create a waveform <b>with modulation</b>: sine, sawtooth, square, triangle, pulse, random S&H or arbitrary.</p>
+	<p align=center><img src="img/waveformsmod.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Frequency or Phase</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Shape (Pulse &amp; Var Triangle)</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Waveform Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>(waveform);</p>
+	<p class=desc>Configure the waveform type to create.
+	</p>
+	<p class=func><span class=keyword>begin</span>(level, frequency, waveform);</p>
+	<p class=desc>Output a waveform, and set the amplitude and base frequency.
+	</p>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Change the base (unmodulated) frequency.
+	</p>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Change the amplitude.  Set to 0 to turn the signal off.
+	</p>
+	<p class=func><span class=keyword>offset</span>(level);</p>
+	<p class=desc>Add a DC offset, from -1.0 to +1.0.  Useful for generating
+		waveforms to use as control or modulation signals.
+	</p>
+	<p class=func><span class=keyword>frequencyModulation</span>(octaves);</p>
+	<p class=desc>
+		Configure for frequency modulation mode (the default) where the
+		input signal will adjust the frequency by a specific number of
+		octaves (the default is 8 octaves).  If the -1.0 to +1.0 signal
+		represents a &plusmn;10 volt range and you wish to have control
+		at 1 volt/octave, then configure for 10 octaves range.  The
+		maximum modulation sensitivity is 12 octaves.
+	</p>
+	<p class=func><span class=keyword>phaseModulation</span>(degrees);</p>
+	<p class=desc>
+		Configure for phase modulation mode where the input signal will
+		adjust the waveform phase angle a specific number of degrees.
+		180.0 allows a full scale &plusmn;1.0 signal to span 1 full
+		cycle of the waveform.  Maximum modulation sensitivity is 9000
+		degrees (&plusmn;25 cycles).
+	</p>
+	<p class=func><span class=keyword>arbitraryWaveform</span>(array, maxFreq);</p>
+	<p class=desc>
+		Configure the waveform to be used with WAVEFORM_ARBITRARY.  Array
+		must be an array of 256 samples.  Currently, the data is used
+		without any filtering, which can cause aliasing with frequencies
+		above 172 Hz.  For higher frequency output, you must bandwidth
+		limit your waveform data.  Someday, "maxFreq" will be used to
+		do this automatically.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; WaveformsModulated
+	</p>
+	<h3>Notes</h3>
+	<p>Supported Waveforms:<br>
+		<ul>
+		<li><span class=literal>WAVEFORM_SINE</span></li>
+		<li><span class=literal>WAVEFORM_SAWTOOTH</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_SAWTOOTH</span></li>
+		<li><span class=literal>WAVEFORM_SAWTOOTH_REVERSE</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_SAWTOOTH_REVERSE</span></li>
+		<li><span class=literal>WAVEFORM_SQUARE</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_SQUARE</span></li>
+		<li><span class=literal>WAVEFORM_TRIANGLE</span></li>
+		<li><span class=literal>WAVEFORM_TRIANGLE_VARIABLE</span></li>
+		<li><span class=literal>WAVEFORM_ARBITRARY</span></li>
+		<li><span class=literal>WAVEFORM_PULSE</span></li>
+		<li><span class=literal>WAVEFORM_BANDLIMIT_PULSE</span></li>
+		<li><span class=literal>WAVEFORM_SAMPLE_HOLD</span></li>
+		</ul>
+	</p>
+	<p>The Sample &amp; Hold waveform does not support phase modulation.
+		Attempting to modulate its phase may give random or
+		inconsistent results.  Use only frequency modulation
+		to vary the Sample &amp; Hold waveform speed
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWaveformModulated">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthWaveformPWM">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create a Pulse Width Modulated waveform, with an audio signal
+		controlling the pulse width duty cycle.</p>
+	<p align=center><img src="img/pwm.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Control Signal Output</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Waveform Output</td></tr>
+	</table>
+	<p>The duty cycle is 50% when the control waveform is zero.
+		As the control input causes a linear changes in PWM duty
+		cycle, from nearly 0 to 100% over -1.0 to +1.0 range.
+		See the notes below for minimum and maximum limitations.
+	</p>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Change the frequency.
+	</p>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Change the amplitude.  Set to 0 to turn the signal off.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>TODO, examples needed
+	</p>
+	<h3>Notes</h3>
+	<p>The maximum duty cycle is 65536 samples high followed by
+		one sample low (99.9985%) and the minimum duty cycle is
+		1 sample high followed by 65536 samples low (0.00153%).
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWaveformPWM">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthToneSweep">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create a continuously varying (in frequency) sine wave</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Continuously varying tone</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>play</span>(level, lowFreq, highFreq, time);</p>
+	<p class=desc>Start generating frequency sweep output.  The time is specified
+		in seconds.  Level is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>isPlaying</span>();</p>
+	<p class=desc>Returns true (non-zero) while the output is active.
+	</p>
+	<p class=func><span class=keyword>read</span>();</p>
+	<p class=desc>Returns the current frequency, or zero if the output is not active.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; ToneSweep
+	</p>
+	<h3>Notes</h3>
+	<p>Uses excessive CPU time.</p>
+	<p>The frequency actually changes in discrete steps every 128 samples (2.9 ms).</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthToneSweep">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthWaveformDc">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create constant (DC) signal, useful for control of objects that take
+		a modulation or control input signal.  This constant level can be
+		used to modify other waveforms using mixer or multiplier objects</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Output constant DC level</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Set the output.  Level is -1.0 to 1.0.  The output is
+		changed immediately.
+	</p>
+	<p class=func><span class=keyword>amplitude</span>(level, milliseconds);</p>
+	<p class=desc>Set the output.  Level is -1.0 to 1.0.  The output is
+		gradually changed over a "milliseconds" time period.  Any time may
+		be specified, but periods longer than 1 second may be automatically
+		shortened for small level changes, due to numerical precision limits.
+	</p>
+	<p class=func><span class=keyword>read</span>();</p>
+	<p class=desc>Read the current level.  Returns -1.0 to 1.0.  This can be
+		useful for monitoring the amplitude after configuring a slow change.
+	</p>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>Of course, the term "DC", for Direct Current, doesn't properly apply
+		to a pure digital stream of numerical values.  But the term is widely
+		understood in audio applications, so hopefully it's not too confusing?</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthWaveformDc">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthNoiseWhite">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create white noise.
+		</p>
+	<p align=center><img src="img/whitenoise.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>White Noise</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Set the output peak level, from 0 (off) to 1.0.
+		The default is off.  Noise is generated only after setting
+		to a non-zero level.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+	<h3>Notes</h3>
+	<p>Setting the amplitude to zero causes this object to stop using
+		CPU time to generate random numbers.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthNoiseWhite">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioSynthNoisePink">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Create pink noise, using Stefan Stenzel's "New Shade Of Pink" algorithm.
+		</p>
+	<!--
+<p align=center><img src="img/whitenoise.png"></p>
+-->
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Pink Noise</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>amplitude</span>(level);</p>
+	<p class=desc>Set the output peak level, from 0 (off) to 1.0.
+		The default is off.  Noise is generated only after setting
+		to a non-zero level.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; MemoryAndCpuUsage
+	</p>
+	<h3>Notes</h3>
+	<p>Setting the amplitude to zero causes this object to stop using
+		CPU time.  CPU usage is approx 3% on Teensy 3.1.
+	</p>
+	<p>Stefan Stenzel's
+		<a href="http://stenzel.waldorfmusic.de/post/pink/" target="_blank">New Shade Of Pink</a>
+		algorithm.  Stefan's terms of use are "Use for any purpose. If used
+		in a commercial product, you should give me one."
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioSynthNoisePink">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectFade">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Gradually increase or decrease audio level.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Signal Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>fadeIn</span>(milliseconds);</p>
+	<p class=desc>Begin increasing the audio level, to reach 1.0 (input passed
+		directly to the output) after "milliseconds" time.
+	</p>
+	<p class=func><span class=keyword>fadeOut</span>(milliseconds);</p>
+	<p class=desc>Begin decreasing the audio level, to reach 0 (no output)
+		after "milliseconds" time.
+	</p>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>Cross fading can be built with 2 fade objects fed into a mixer.
+		When one fade object is off (fully faded out) and the other on
+		(fully faded in), if both are started at the same moment for the
+		same time duration, their signal gains always add to 1.0.  This
+		allows 2 fade objects to work together for a smooth transition
+		between a pair of signals.
+	</p>
+	<p><a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+		should be used when changing
+		settings on multiple objects, so all changes always take effect
+		at the same moment.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectFade">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectChorus">
+<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>The chorus effect simulates the richness of several nearly-identical
+	sound sources (like the way a choir sounds different to a single singer).
+	It does this by sampling from a delay line, so each voice is actually
+	the same but at a slightly different point in time. This is a type of
+	comb filtering.</p>
+	</div>
+	<p>Chorus combines one or more samples ranging from the most recent
+	sample back to about 50ms ago. The additional samples are evenly spread
+	through the supplied delay line, and there is no modulation.</p>
+	<p>If the number of voices is specified as 2, then the
+	effect combines the current sample and the oldest sample (the last one
+	in the delay line). If the number of voices is 3 then the effect combines
+	the most recent sample, the oldest sample and the sample in the middle of
+	the delay line.</p>
+	<p>For two voices the effect can be represented as:<br/>
+	result = (sample(0) + sample(dt))/2<br/>
+	where sample(0) represents the current sample and sample(dt)
+	is the sample in the delay line from dt milliseconds ago.</p>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class="top"><th>Port</th><th>Purpose</th></tr>
+		<tr class="odd"><td align="center">In 0</td><td>Signal Input</td></tr>
+		<tr class="odd"><td align="center">Out 0</td><td>Chorused Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>(delayBuffer, length, n_chorus);</p>
+	<p class=desc>Create a chorus by specifying the address of the delayline, the
+	total number of samples in the delay line (often done as an integer multiple of
+	AUDIO_BLOCK_SAMPLES) and the number of voices in the chorus <em>including</em>
+	the original voice (so, 2 and up to get a chorus effect, although you can
+	specify 1 if you want).
+	</p>
+	<p class=func><span class=keyword>voices</span>(n_chorus);</p>
+	<p class=desc>Alters the number of voices in a running chorus (previously started with begin).
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Chorus
+	</p>
+	<h3>Notes</h3>
+	<p>The longer the length of the chorus, the more memory blocks are used.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectChorus">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectFlange">
+<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Originally, flanging was produced by playing the same signal on two synchronized
+	reel-to-reel tape recorders and making one of the reels slow down and speed up by
+	pressing on the flange of the reel (hence the name). This is a type of
+	comb filtering, and produces a harmonically-related series of peaks and notches
+	in the audio spectrum.</p>
+	</div>
+	<p>This flanger uses a delay line, combining the original voice with only one sample from the delay
+	line, but the position of that sample varies sinusoidally.</p>
+	<p>The effect can be represented as:<br>
+	result = sample(0) + sample(dt + depth*sin(2*PI*Fe))</p>
+	<p>The value of the sine function is always a number from -1 to +1 and
+	so the result of depth*(sin(Fe)) is always a number from -depth to +depth.
+	Thus, the delayed sample will be selected from the range (dt-depth) to
+	(dt+depth). This selection will vary at whatever rate is specified as the
+	frequency of the effect, Fe. Typically a low frequency (a few Hertz) is used.
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class="top"><th>Port</th><th>Purpose</th></tr>
+		<tr class="odd"><td align="center">In 0</td><td>Signal Input</td></tr>
+		<tr class="odd"><td align="center">Out 0</td><td>Flanged Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>(delayBuffer, length, offset, depth, delayRate);</p>
+	<p class=desc>Create a flanger by specifying the address of the delayline, the
+	total number of samples in the delay line (often done as an integer multiple of
+	AUDIO_BLOCK_SAMPLES), the offset (how far back the flanged sample is from the original voice),
+	the modulation depth (larger values give a greater variation) and the modulation
+	frequency, in Hertz.
+	</p>
+	<p class=func><span class=keyword>voices</span>(offset, depth, delayRate);</p>
+	<p class=desc>Alters the parameters in a running flanger (previously started with begin).
+	</p>
+
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Flange
+	</p>
+	<h3>Notes</h3>
+	<p>The longer the length of the delay buffer, the more memory blocks are used.</p>
+	<p>Try these settings:<br>
+#define FLANGE_DELAY_LENGTH (2*AUDIO_BLOCK_SAMPLES)<br>
+and<br>
+int s_idx = 2*FLANGE_DELAY_LENGTH/4;<br>
+int s_depth = FLANGE_DELAY_LENGTH/4;<br>
+double s_freq = 3;</p>
+<p>The flange effect can also produce a chorus-like effect if a longer
+delay line is used with a slower modulation rate, for example try:<br>
+#define FLANGE_DELAY_LENGTH (12*AUDIO_BLOCK_SAMPLES)<br>
+and<br>
+int s_idx = 3*FLANGE_DELAY_LENGTH/4;<br>
+int s_depth = FLANGE_DELAY_LENGTH/8;<br>
+double s_freq = .0625;</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectFlange">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectReverb">
+<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Reverb with adjustable reverberation time.  Contributed by Joao Rossi FIlho.
+	</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class="top"><th>Port</th><th>Purpose</th></tr>
+		<tr class="odd"><td align="center">In 0</td><td>Input</td></tr>
+		<tr class="odd"><td align="center">Out 0</td><td>Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>reverbTime</span>(seconds);</p>
+	<p class=desc>Sets the amount of reverberation time.
+	</p>
+
+	<h3>Examples</h3>
+	<p><a href="https://twitter.com/joaorossifilho/status/779737126841753601">Video Demo</a>
+	</p>
+	<!--<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Flange
+	</p>-->
+	<h3>Notes</h3>
+	<p>This effect may have distortion problems with the input signal is more than 0.5.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectReverb">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectFreeverb">
+<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>High quality Reverb effect, based on Freeverb by Jezar at Dreampoint.
+	</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class="top"><th>Port</th><th>Purpose</th></tr>
+		<tr class="odd"><td align="center">In 0</td><td>Input</td></tr>
+		<tr class="odd"><td align="center">Out 0</td><td>Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>roomsize</span>(amount);</p>
+	<p class=desc>Sets the amount of reverberant echo or apparent room
+		size, from 0 (smallest) to 1.0 (largest);
+	</p>
+	<p class=func><span class=keyword>damping</span>(amount);</p>
+	<p class=desc>Sets the damping factor, from 0 to 1.0.  More damping
+		causes higher frequency echo to decay, creating a softer sound,
+		similar to a large room filled with people or materials which
+		absorb some sound as it travels between reflecting surfaces.
+		Lower damping simulates a harsher reverberant field.
+	</p>
+
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Freeverb
+		</p>
+	<h3>Notes</h3>
+	<p>Freeverb mono consumes about 21% of the CPU time on Teensy 3.2 and
+		requires about 22K of RAM.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectFreeverb">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectFreeverbStereo">
+<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>High quality stereo Reverb effect, based on Freeverb by Jezar at Dreampoint.
+	</p>
+	<p>Teensy 3.5 or 3.6 required to run stereo version.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class="top"><th>Port</th><th>Purpose</th></tr>
+		<tr class="odd"><td align="center">In 0</td><td>Input</td></tr>
+		<tr class="odd"><td align="center">Out 0</td><td>Left Output</td></tr>
+		<tr class="odd"><td align="center">Out 1</td><td>Right Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>roomsize</span>(amount);</p>
+	<p class=desc>Sets the amount of reverberant echo or apparent room
+		size, from 0 (smallest) to 1.0 (largest);
+	</p>
+	<p class=func><span class=keyword>damping</span>(amount);</p>
+	<p class=desc>Sets the damping factor, from 0 to 1.0.  More damping
+		causes higher frequency echo to decay, creating a softer sound,
+		similar to a large room filled with people or materials which
+		absorb some sound as it travels between reflecting surfaces.
+		Lower damping simulates a harsher reverberant field.
+	</p>
+
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Freeverb_Stereo
+		</p>
+	<h3>Notes</h3>
+	<p>Freeverb mono consumes about 18% of the CPU time on Teensy 3.6 and
+		requires about 45K of RAM.</p>
+	<p>Teensy 3.2 does not have enough RAM to
+		run this effect while playing WAV file and implementing USB Serial.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectFreeverbStereo">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectEnvelope">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Modify a signal with a DAHDSR (Delay Attack Hold Decay Sustain
+		Release) envelope.
+	</p>
+	<p align=center><img src="img/dahdsr.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Signal with Envelope Applied</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>noteOn</span>();</p>
+	<p class=desc>Begin the delay to attack, or the attack phase is
+		delay is zero.
+	</p>
+	<p class=func><span class=keyword>noteOff</span>();</p>
+	<p class=desc>Begin the release phase.
+	</p>
+	<p class=func><span class=keyword>delay</span>(milliseconds);</p>
+	<p class=desc>Set the delay from noteOn to the attach phase.  The
+		default is zero, for no delay.
+	</p>
+	<p class=func><span class=keyword>attack</span>(milliseconds);</p>
+	<p class=desc>Set the attack time.  The default is 10.5 milliseconds.
+		The maximum is 11880 milliseconds.
+	</p>
+	<p class=func><span class=keyword>hold</span>(milliseconds);</p>
+	<p class=desc>Set the hold time.  The default is 2.5 milliseconds.
+		The maximum is 11880 milliseconds.
+	</p>
+	<p class=func><span class=keyword>decay</span>(milliseconds);</p>
+	<p class=desc>Set the decay time.  The default is 35 milliseconds.
+		The maximum is 11880 milliseconds.
+	</p>
+	<p class=func><span class=keyword>sustain</span>(level);</p>
+	<p class=desc>Set the sustain level.  The range is 0 to 1.0.  The
+		gain will be maintained at this level after the decay phase,
+		until noteOff() is called.  The sustain phase may last any
+		length of time, controlled by when release() is called.
+	</p>
+	<p class=func><span class=keyword>release</span>(milliseconds);</p>
+	<p class=desc>Set the release time.  The default is 300 millisecond.
+		The maximum is 11880 milliseconds.
+	</p>
+	<p class=func><span class=keyword>releaseNoteOn</span>(milliseconds);</p>
+	<p class=desc>Set a quick release time to be used when a new note is
+		started while the envelop is in any state passing the signal.
+		This will add latency before your new attack phase begins, so
+		short times are recommended.  Zero may be used to completely
+		disable this feature (never extra latency).  Longer times help
+		reduce clicks or pops.  The default is 5 millisecond.
+	</p>
+	<p class=func><span class=keyword>isActive</span>();</p>
+	<p class=desc>Returns true when the envelope is currently in any of
+		its 6 phases.
+	</p>
+	<p class=func><span class=keyword>isSustain</span>();</p>
+	<p class=desc>Returns true when the envelope is currently in the
+		sustain phase.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; PlaySynthMusic
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; pulseWidth
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; MemoryAndCpuUsage
+	</p>
+	<h3>Notes</h3>
+	<p>To achieve the more common ADSR shape, simply
+        set delay and hold to zero.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectEnvelope">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectMultiply">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Multiply two signals together, useful for amplitude modulation
+		or "voltage controlled amplification".
+	</p>
+	<p align=center><img src="img/multiply.png"><br><small>56 Hz and 1 kHz sine waves multiplied.</small></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Signal with Envelope Applied</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>There are no functions to call from the Arduino sketch.
+		This object simply multiplies the 2 signals to create
+		a continuous output
+	</p>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>
+    </p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectMultiply">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectWaveFolder">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Multiply two signals together and apply wavefolding, useful for modulatable distortion;
+           use one input as a depth control from LFO or DC signal.  Rather than saturating the signal
+           folds back on itself when overloaded - extra gain means the modulating signal starts to cause
+           folding of a full-scale waveform at about 6% modulation, allowing a maximum folding factor of 16.
+	</p>
+	<p align=center><img src="img/wavefolder.png"><br><small>70 Hz sine wave distorted with wave-folding.</small></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Modulation Input</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Signal with Folding Applied</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>There are no functions to call from the Arduino sketch.
+		This object simply combined the 2 signals and then wave-folds
+	</p>
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; WaveFolder</p>
+	<h3>Notes</h3>
+	<p>Assumes the AudioShield fitted.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectWaveFolder">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectRectifier">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Invert the negative portion of a signal, similar to a full wave rectifier circuit.
+	</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Rectifed (positive only) Signal</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>There are no functions to call from the Arduino sketch.
+		This object simply passes the positive portion of the
+		signal and inverts the signal when the input is negative.
+	</p>
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Vocoder19Band
+	</p>
+	<h3>Notes</h3>
+	<p>To create a half wave rectifier effect, use the waveshape effect.  See
+		<a href="https://forum.pjrc.com/threads/62091?p=255367&viewfull=1#post255367">this forum message</a> for a half-wave rectifier example.
+	</p>
+    </p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectRectifier">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectDelay">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Delay a signal.  Up to 8 separate delay taps can be used.</p>
+	<p align=center><img src="img/delay.png"><br><small>1 kHz burst, delayed 5.2 ms.</small></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Delay Tap #1</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Delay Tap #2</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Delay Tap #3</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Delay Tap #4</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Delay Tap #5</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Delay Tap #6</td></tr>
+		<tr class=odd><td align=center>Out 6</td><td>Delay Tap #7</td></tr>
+		<tr class=odd><td align=center>Out 7</td><td>Delay Tap #8</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>delay</span>(channel, milliseconds);</p>
+	<p class=desc>Set output channel (0 to 7) to delay the signals by
+		milliseconds.  See the table below for the maximum delay.  The actual delay
+		is rounded to the nearest sample.  Each channel can be configured for
+		any delay.  There is no requirement to configure the "taps" in increasing
+		delay order.
+	</p>
+	<p class=func><span class=keyword>disable</span>(channel);</p>
+	<p class=desc>Disable a channel.  The output of this channel becomes
+		silent.  If this channel is the longest delay, memory usage is
+		automatically reduced to accommodate only the remaining channels used.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Delay
+	</p>
+	<h3>Notes</h3>
+	<p>Memory for the delayed signal is take from the memory pool allocated by
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioConnection.html" target="_blank">AudioMemory()</a>.
+		Each block allows about 2.9 milliseconds of delay, so AudioMemory
+		should be increased to allow for the longest delay tap.
+	</p>
+	<p>Each board has a maximum possible delay.
+	</p>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Board</th><th>Maximum</th></tr>
+		<tr class=odd><td>Teensy 3.0</td><td align=center>139.26 ms</td></tr>
+		<tr class=odd><td>Teensy 3.1</td><td align=center>449.39 ms</td></tr>
+		<tr class=odd><td>Teensy 3.2</td><td align=center>449.39 ms</td></tr>
+		<tr class=odd><td>Teensy 3.5</td><td align=center>1671.19 ms</td></tr>
+		<tr class=odd><td>Teensy 3.6</td><td align=center>2413.94 ms</td></tr>
+	</table>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectDelay">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectDelayExternal">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Delay a signal, using external memory for longer delay times!  Up to 8 separate delay taps can be used.</p>
+	<p align=center><img src="img/delay.png"><br><small>1 kHz burst, delayed 5.2 ms.</small></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Delay Tap #1</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Delay Tap #2</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Delay Tap #3</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Delay Tap #4</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Delay Tap #5</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Delay Tap #6</td></tr>
+		<tr class=odd><td align=center>Out 6</td><td>Delay Tap #7</td></tr>
+		<tr class=odd><td align=center>Out 7</td><td>Delay Tap #8</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>delay</span>(channel, milliseconds);</p>
+	<p class=desc>Set output channel (0 to 7) to delay the signals by
+		milliseconds.  The maximum delay is approx 1.5 seconds for each 23LC1024 chip.
+		The actual delay
+		is rounded to the nearest sample.  Each channel can be configured for
+		any delay.  There is no requirement to configure the "taps" in increasing
+		delay order.
+	</p>
+	<p class=func><span class=keyword>disable</span>(channel);</p>
+	<p class=desc>Disable a channel.  The output of this channel becomes silent.
+	</p>
+	<h3>Hardware</h3>
+	<p>By default, or when <span class=literal>AUDIO_MEMORY_23LC1024</span> is used (see below),
+		 a single 23LC1024 RAM chip is used, with these pins:
+    <table class=doc align=center cellpadding=3>
+        <tr class=top><th>Pin</th><th>Signal</th></tr>
+        <tr class=odd><td align=center>6</td><td>CS</td></tr>
+        <tr class=odd><td align=center>7</td><td>MOSI</td></tr>
+        <tr class=odd><td align=center>12</td><td>MISO</td></tr>
+        <tr class=odd><td align=center>14</td><td>SCK</td></tr>
+    </table>
+	</p>
+	<p>When <span class=literal>AUDIO_MEMORY_CY15B104</span> is used, a single
+		CY15B104 FRAM chip is used, with these pins:
+    <table class=doc align=center cellpadding=3>
+        <tr class=top><th>Pin</th><th>Signal</th></tr>
+        <tr class=odd><td align=center>6</td><td>CS</td></tr>
+        <tr class=odd><td align=center>7</td><td>SI</td></tr>
+        <tr class=odd><td align=center>12</td><td>SO</td></tr>
+        <tr class=odd><td align=center>14</td><td>SCK</td></tr>
+    </table>
+	</p>
+	<p>When <span class=literal>AUDIO_MEMORY_MEMORYBOARD</span> is used, up to six
+		23LC1024 chips are used.
+	</p>
+	<p align=center><img src="img/memoryboard.jpg"><br><small><a href="https://oshpark.com/shared_projects/KZt5PaU7" target="_blank">Memoryboard 4</a></small></p>
+	<p>
+    <table class=doc align=center cellpadding=3>
+        <tr class=top><th>Pin</th><th>Signal</th></tr>
+        <tr class=odd><td align=center>2</td><td>CS0 (encoded)</td></tr>
+        <tr class=odd><td align=center>3</td><td>CS1 (encoded)</td></tr>
+        <tr class=odd><td align=center>4</td><td>CS2 (encoded)</td></tr>
+        <tr class=odd><td align=center>7</td><td>MOSI</td></tr>
+        <tr class=odd><td align=center>12</td><td>MISO</td></tr>
+        <tr class=odd><td align=center>14</td><td>SCK</td></tr>
+    </table>
+	</p>
+	<p>
+	If fewer than 6 chips are soldered, the optional parameter for maximum delay
+	must be used.  See below for details.  Each chip provides 1485 ms of delay
+	memory, so the total of all objects using AUDIO_MEMORY_MEMORYBOARD must not
+	exceed the amount of memory physically present.
+	</p>
+	<h3>Examples</h3>
+	<p>
+	<a href="https://www.youtube.com/watch?v=d80d1HWy5_s" target="_blank">Demo Video</a> (YouTube)
+	</p>
+	<!--
+ <p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Delay
+	</p>
+-->
+	<p>
+	<a href="https://forum.pjrc.com/threads/29276-Limits-of-delay-effect-in-audio-library?p=79436&viewfull=1#post79436" target="_blank">Forum Conversaton</a> (with sample code)
+	</p>
+	<h3>Notes</h3>
+	<p>External RAM allows for longer delays without consuming
+		limited internal RAM.  However, SPI communication is required,
+		which consumes much more CPU time.  The
+		<a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html">AudioProcessorUsageMax</a>
+		function may be used to monitor how much CPU time is consumed.
+	</p>
+	<p>You may specify the type of hardware to be used by editing the code.  AUDIO_MEMORY_23LC1024
+		specifies a single 23LC1024 chip.  AUDIO_MEMORY_MEMORYBOARD allows using up to 6 of these
+		chips.
+	</p>
+	<p class=desc><span class=keyword>AudioEffectDelayExternal</span>  delayExt1(<span class=literal>AUDIO_MEMORY_23LC1024</span>);
+	</p>
+	<p>You may also create more than one delay using the same hardware, where the memory is partitioned
+		by specifying a maximum delay in milliseconds.  This can be useful if you wish to delay both
+		channels of a stereo signal.
+
+	<p class=desc><span class=keyword>AudioEffectDelayExternal</span>  delayExt1(<span class=literal>AUDIO_MEMORY_23LC1024</span>, 700);<br><span class=keyword>AudioEffectDelayExternal</span>  delayExt2(<span class=literal>AUDIO_MEMORY_23LC1024</span>, 700);
+	</p>
+	<p>When using CY15B104, you
+		<a href="https://forum.pjrc.com/threads/45872-Memory-Chip-for-Audio-Adaptor-Board?p=151839&viewfull=1#post151839">may need to add a capacitor between 3.3V & GND</a>
+		to make the chip work.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectDelayExternal">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectBitcrusher">
+    <h3>Summary</h3>
+	<div class=tooltipinfo>
+    <p>Reduce the samplerate and/or bitdepth of a source signal, resulting in
+		a distorted sound.</p>
+	</div>
+    <h3>Audio Connections</h3>
+    <table class=doc align=center cellpadding=3>
+        <tr class=top><th>Port</th><th>Purpose</th></tr>
+        <tr class=odd><td align=center>In 0</td><td>Signal Input</td></tr>
+        <tr class=odd><td align=center>Out 0</td><td>Signal Output</td></tr>
+    </table>
+    <h3>Functions</h3>
+    <p class=func><span class=keyword>bits</span>(xcrushBits);</p>
+    <p class=desc>xcrushBits sets the bitdepth, from 1 to 16. A Value of 16
+    does not crush the bitdepth, and is effectively a passthru for this part
+    of the function.</p>
+
+    <p class=func><span class=keyword>sampleRate</span>(xsampleRate);</p>
+
+    <p class=desc>xsampleRate sets the frequency, from 1 to 44100Hz, however it
+    works in integer steps so you will only really get a handful of results from
+    the many samplerates you can pass. 44100 is passthru.</p>
+
+    <p class=desc>set xbitDepth to 16 and xsampleRate to 44100 to pass audio
+    	through without any Bitcrush effect.</p>
+    <h3>Examples</h3>
+    <p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Bitcrusher
+    </p>
+    <h3>Notes</h3>
+    <p>Needs a lot of improvement. Options for anti-aliasing would be nice in
+    the future, but for now, it's rough, it's dirty and it sounds a bit like
+    Nine Inch Nails.
+    </p>
+    <p><a href="http://www.pjrc.com/teensy/td_libs_AudioProcessorUsage.html" target="_blank">AudioNoInterrupts()</a>
+        should be used when changing
+        settings on multiple objects, so all changes always take effect
+        at the same moment.
+    </p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectBitcrusher">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectMidSide">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Convert stereo signals to/from Mid-Side format.
+		Mid-Side encoding can be used to increase stereo width, make the lower
+		frequencies mono (to please your sub), or as the basis of audio compression.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>While<br>Encoding</th><th>While<br>Decoding</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Left Input</td><td>Mid Output</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Right Input</td><td>Side Output</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Mid Input</td><td>Left Output</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Side Input</td><td>Right Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>encode</span>();</p>
+	<p class=desc>Configure this object to encode from stereo to Mid-Side format.</p>
+	<p class=func><span class=keyword>decode</span>();</p>
+	<p class=desc>Configure this object to decode from Mid-Side format back to stereo signals.</p>
+
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Mid_Side</p>
+	<h3>Notes</h3>
+	<p>Many interesting stereo effects can be achieved by manipulating Mid-Side signals.</p>
+	<p>Normally a pair of these objects are used, one to encode, then additional
+		gain/attenuation or effects applied to the Mid-Side signals, and finally
+		decoding back to stereo signals</p>
+	<p>To prevent saturation, halving is done in the encoding, that is:</p>
+	<p>Mid = (left+right)/2</p>
+	<p>Side = (left-right)/2</p>
+	<p>And to decode:</p>
+	<p>Left = Mid+Side</p>
+	<p>Right = Mid-Side</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectMidSide">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectWaveshaper">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Modify the waveform shape of a signal.</p>
+	<p align=center><img src="img/waveshaper.png"></p>
+	<p>Useful for overdrive, distortion, fuzz,
+		clipping, expo converters, phase inversion, waveform modification &amp; adjustments.
+	</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Signal</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Original Input Signal</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Shaped Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>shape</span>(array, length);</p>
+	<p class=desc>Configure the waveform shape.  Array is a list of float
+		numbers, given in order.  The first number maps to input -1.0.  The
+		last maps to input +1.0.  The numbers represent the desired output
+		level at each of these input levels.  Length must be 2, 3, 5, 9, 17,
+		33, 65, 129, 257, 513, 1025, 2049, 4097, 8193, 16385, or 32769.
+		</p>
+
+	<h3>Examples</h3>
+	<p class=exam>TODO: example needed</p>
+	<!--<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Mid_Side</p>-->
+	<h3>Notes</h3>
+	<p><a href="https://github.com/dxinteractive/TeensyAudioWaveshaper">More information</a>
+		</p>
+</script>
+<script type="text/x-red" data-template-name="AudioEffectWaveshaper">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectGranular">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Classic granular effect that uses a variable speed buffer to shift the pitch
+		and freeze incoming audio.
+		Contributed by Bleep Labs.
+	</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Signal</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Input Signal</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Granular Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>(array, length);</p>
+	<p class=desc>Initialize the granular processing with an array of 16 bit
+		integers used to store the sound grains.  Until memory is allocated
+		with this function, no audio appears at the output.
+		</p>
+	<p class=func><span class=keyword>setSpeed</span>(ratio);</p>
+	<p class=desc>Configure the relative speed grains will be played.  1.0
+		plays the grains without any change.  Less than 1.0 slows the sound,
+		and greater than 1.0 speeds up.  The allowed range is 0.125 to 8.0,
+		for &plusmn;3 octaves shift.
+		</p>
+	<p class=func><span class=keyword>beginFreeze</span>(grainLength);</p>
+	<p class=desc>Freeze the sound by sampling one grain, then repeated playing
+		it.  The grainLength is specified in milliseconds, up to the size allowed
+		by the array from begin().
+		</p>
+	<p class=func><span class=keyword>beginPitchShift</span>(grainLength);</p>
+	<p class=desc>Pitch shift by continuously sampling grains and playing them
+		at altered speed.  The grainLength is specified in milliseconds, up to
+		one third of the memory from begin();
+		</p>
+	<p class=func><span class=keyword>stop</span>();</p>
+	<p class=desc>Stop granual processing.  The input signal is passed to the
+		output without any changes.
+		</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Granular</p>
+	<!--<h3>Notes</h3>
+	<p> </p>-->
+</script>
+<script type="text/x-red" data-template-name="AudioEffectGranular">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioEffectDigitalCombine">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Combine signals with digital logic functions, with results from
+		interesting new waveforms to aggressive digital distortion.
+		Contributed by Bleep Labs.
+	</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Signal</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Input Signal #1</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Input Signal #2</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Combined Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>setCombineMode</span>(mode);</p>
+	<p class=desc>Configure which digital combine operation is performed.
+	</p>
+	<p class=desc>Supported modes:<br>
+		<span class=keyword>AudioEffectDigitalCombine</span><b>::OR</b><br>
+		<span class=keyword>AudioEffectDigitalCombine</span><b>::XOR</b><br>
+		<span class=keyword>AudioEffectDigitalCombine</span><b>::AND</b><br>
+		<span class=keyword>AudioEffectDigitalCombine</span><b>::MODULO</b><br>
+	</p>
+	<h3>Examples</h3>
+	<!--<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Combine</p>-->
+	<!--<h3>Notes</h3>
+	<p> </p>-->
+</script>
+<script type="text/x-red" data-template-name="AudioEffectDigitalCombine">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioFilterBiquad">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Biquadratic cascaded filter, useful for all sorts of filtering.
+		Up to 4 stages may be cascaded.
+	</p>
+	<p align=center><img src="img/biquad.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to be filtered</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Filtered Signal Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>setLowpass</span>(stage, frequency, Q);</p>
+	<p class=desc>Configure one stage of the filter (0 to 3) with low pass
+		response, with the specified corner frequency and Q shape.  If Q is
+		higher that 0.7071, be careful of filter gain (see below).
+	</p>
+	<p class=func><span class=keyword>setHighpass</span>(stage, frequency, Q);</p>
+	<p class=desc>Configure one stage of the filter (0 to 3) with high pass
+		response, with the specified corner frequency and Q shape.  If Q is
+		higher that 0.7071, be careful of filter gain (see below).
+	</p>
+	<p class=func><span class=keyword>setBandpass</span>(stage, frequency, Q);</p>
+	<p class=desc>Configure one stage of the filter (0 to 3) with band pass
+		response.  The filter has unity gain at the specified frequency.  Q
+		controls the width of frequencies allowed to pass.
+	</p>
+	<p class=func><span class=keyword>setNotch</span>(stage, frequency, Q);</p>
+	<p class=desc>Configure one stage of the filter (0 to 3) with band reject (notch)
+		response.  Q controls the width of rejected frequencies.
+	</p>
+	<p class=func><span class=keyword>setLowShelf</span>(stage, frequency, gain, slope);</p>
+	<p class=desc>Configure one stage of the filter (0 to 3) with low shelf response.
+		A low shelf filter attenuates or amplifies signals below the specified frequency.
+		Frequency controls the slope midpoint, gain is in dB and can be both
+		positive or negative. The slope parameter controls steepness of gain transition.
+		A slope of 1 yields maximum steepness without overshoot,
+		lower values yield a less steep slope. See the picture below for a visualization
+		of the slope parameter's effect.
+		Be careful with positive gains and slopes higher than 1 as they introduce gain
+		(see warning below).
+	</p>
+	</p>
+	<p class=func><span class=keyword>setHighShelf</span>(stage, frequency, gain, slope);</p>
+	<p class=desc>Configure one stage of the filter (0 to 3) with high shelf response.
+		A high shelf filter attenuates or amplifies signals above the specified frequency.
+		Frequency controls the slope midpoint, gain is in dB and can be both
+		positive or negative. The slope parameter controls steepness of gain transition.
+		A slope of 1 yields maximum steepness without overshoot,
+		lower values yield a less steep slope. See the picture below for a visualization
+		of the slope parameter's effect.
+		Be careful with positive gains and slopes higher than 1 as they introduce gain
+		(see warning below).
+	</p>
+	<p align=center><img src="img/shelf_filter.png"></p>
+	<p class=func><span class=keyword>setCoefficients</span>(stage, array[5]);</p>
+	<p class=desc>Configure one stage of the filter (0 to 3) with an arbitrary
+		filter response.  The array of coefficients is in order: B0, B1, B2, A1, A2.
+		Each coefficient must be less than 2.0 and greater than -2.0.  The array
+		should be type double.  Alternately, it may be type int, where 1.0 is
+		represented with 1073741824 (2<sup>30</sup>).
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Filter
+	</p>
+	<h3>Notes</h3>
+	<p>Filters can with gain must have their input signals attenuated, so the
+		signal does not exceed 1.0.
+	</p>
+	<p>This object implements up to 4 cascaded stages.  Unconfigured stages will
+		not pass any signal.
+	</p>
+	<p>Biquad filters with low corner frequency (under about 400 Hz) can run into
+		trouble with limited numerical precision, causing the filter to perform
+		poorly.  For very low corner frequency, the State Variable (Chamberlin)
+		filter should be used.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioFilterBiquad">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioFilterFIR">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Finite impulse response filter, useful for all sorts of filtering.
+	</p>
+	<p align=center><img src="img/fir_filter.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to be filtered</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Filtered Signal Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>(array, length);</p>
+	<p class=desc>Initialize the filter.  The array must be 16 bit integers (the
+		filter's impulse response), and
+		length indicates the number of points in the array.  Array may also be
+		FIR_PASSTHRU (length = 0), to directly pass the input to output without
+		filtering.
+	</p>
+	<p class=func><span class=keyword>end</span>();</p>
+	<p class=desc>Turn the filter off.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Effects &gt; Filter_FIR
+	</p>
+	<h3>Known Issues</h3>
+	<p>Your filter's impulse response array must have an even length.  If you have
+		add odd number of taps, you must add an extra zero to increase the length
+		to an even number.
+	</p>
+	<p>The minimum number of taps is 4.  If you use less, add extra zeros to increase
+		the length to 4.
+	</p>
+	<p>The impulse response must be given in reverse order.  Many filters have
+		symetrical impluse response, making this a non-issue.  If your filter has
+		a non-symetrical response, make sure the data is in reverse time order.
+	</p>
+	<h3>Notes</h3>
+	<p>FIR filters requires more CPU time than Biquad (IIR), but they can
+		implement filters with better phase response.
+	</p>
+	<p>A 100 point filter requires 9% CPU time on Teensy 3.1.  The maximum
+		supported filter length is 200 points.
+	</p>
+	<p>The free
+		<a href="http://t-filter.engineerjs.com/" target="_blank"> TFilter Design Tool</a>
+		can be used to create the impulse response array.  Be sure to set the sampling
+		frequency to 44117 HZ (it defaults to only 2000 Hz) and the output type to "int" (16 bit).
+	</p>
+	<p>
+		If you use TFilter Design's "C/C++ array" option, it's output has "int" definition, which
+		is 32 bits on Teensy 3.1.  Edit "int" to "short" for an array of 16 bit numbers,
+		and add "const" to avoid consuming extra RAM.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioFilterFIR">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioFilterStateVariable">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>A State Variable (Chamberlin) Filter with 12 dB/octave roll-off,
+		adjustable resonance, and optional signal control of corner
+		frequency.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to Filter</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Frequency Control</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Low Pass Output</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Band Pass Output</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>High Pass Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Set the filter's corner frequency.  When a signal is
+		connected to the control input, the filter will implement this
+		frequency when the signal is zero.
+	</p>
+	<p class=func><span class=keyword>resonance</span>(Q);</p>
+	<p class=desc>Set the filter's resonance.  Q ranges from 0.7 to 5.0.
+		Resonance greater than 0.707 will amplify the signal near the
+		corner frequency.  You must attenuate the signal before input
+		to this filter, to prevent clipping.
+	</p>
+	<p class=func><span class=keyword>octaveControl</span>(octaves);</p>
+	<p class=desc>Set how much (in octaves) the control signal can alter
+		the filter's corner frequency.  Range is 0 to 7 octaves.  For
+		example, when set to 2.5, a full scale positive signal (1.0) will
+		shift the filter frequency up 2.5 octaves, and a full scale negative
+		signal will shift it down 2.5 octaves.
+	</p>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>
+		When controlled by a signal, the equation for the filter
+		frequency is:
+	</p>
+	<p>
+		<img src="img/filter_formula.png">
+	</p>
+	<p>When operating with signal control of corner frequency, this
+		object uses approximately 4% of the CPU time on Teensy 3.1.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioFilterStateVariable">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+<script type="text/x-red" data-help-name="AudioFilterLadder">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>A low pass filter with resonant feedback, meant to approximate the
+		classic "Moog sound".  Both cut-off frequency and resonance level
+		can optionally be controlled by input audio signals.
+		</p>
+	<p align=center><img src="img/ladder.png"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to Filter</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Frequency Control</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Resonance Control</td></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Low Pass Output</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Set the filter's corner frequency.  When a signal is
+		connected to the frequency control input, this setting is
+		the corner frequency the filter will implement
+		when the signal is zero.
+	</p>
+	<p class=func><span class=keyword>octaveControl</span>(octaves);</p>
+	<p class=desc>Set how much (in octaves) the control signal can alter
+		the filter's corner frequency.  Range is 0 to 7 octaves.  For
+		example, when set to 2.5, a full scale positive signal (1.0) will
+		shift the filter frequency up 2.5 octaves, and a full scale negative
+		signal will shift it down 2.5 octaves.
+	</p>
+	<p class=func><span class=keyword>resonance</span>(level);</p>
+	<p class=desc>Set the filter's feedback level for resonance.  The
+		usable range is 0 to 1.8, where values over 1.0 can cause
+		the filter to self oscillate.  When an audio signal is present
+		at the resonance control input, it adds to (positive signal)
+		or subtracts from (negative signal) this setting.  To achieve
+		maximum resonance when the control signal is at its 1.0 maximum
+		amplitude, this setting must be at least 0.8.
+	</p>
+	<p class=func><span class=keyword>inputDrive</span>(level);</p>
+	<p class=desc>TODO: add info here...<br>
+		range is 0 to 4.0
+	</p>
+	<p class=func><span class=keyword>passbandGain</span>(gain);</p>
+	<p class=desc>TODO: add info here...<br>
+		range is 0 to 0.5
+	</p>
+	<p class=func><span class=keyword>interpolationMethod</span>(method);</p>
+	<p class=desc>TODO: add info here...<br>
+		<span class=literal>LADDER_FILTER_INTERPOLATION_FIR_POLY</span><br>
+		<span class=literal>LADDER_FILTER_INTERPOLATION_LINEAR</span><br>
+	</p>
+
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Synthesis &gt; LadderFilter
+	</p>
+	<h3>Notes</h3>
+	<p>	Teensy 3.5 is the minimum hardware capable of running this filter.
+	</p>
+	<p>	When controlled by a signal, the equation for the filter
+		frequency is:
+	</p>
+	<p>
+		<img src="img/filter_formula.png">
+	</p>
+	<p>This filter uses floating point math.  It is recommended for use
+		on Teensy 4.0 or higher.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioFilterLadder">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAnalyzePeak">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Track the signal peak amplitude.  Very useful for simple
+		audio level response projects, and general troubleshooting.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to analyze</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>available</span>();</p>
+	<p class=desc>Returns true each time new peak data is available.
+	</p>
+	<p class=func><span class=keyword>read</span>();</p>
+	<p class=desc>Read the highest peak amplitude value since the last read.
+		Return is from 0.0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>readPeakToPeak</span>();</p>
+	<p class=desc>Read the highest peak-to-peak amplitude since the last read.
+		Return is from 0.0 to 2.0.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; PeakMeterMono
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; PeakMeterStereo
+	</p>
+	<h3>Notes</h3>
+	<p></p>
+</script>
+<script type="text/x-red" data-template-name="AudioAnalyzePeak">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAnalyzeRMS">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Track the signal RMS amplitude.  Useful for
+		audio level response projects, and general troubleshooting.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to analyze</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>available</span>();</p>
+	<p class=desc>Returns true if new RMS data is available.
+	</p>
+	<p class=func><span class=keyword>read</span>();</p>
+	<p class=desc>Read the new RMS value.
+		Return is from 0.0 to 1.0.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; PeakAndRMSMeterStereo</p>
+	</p>
+	<h3>Notes</h3>
+	<p></p>
+</script>
+<script type="text/x-red" data-template-name="AudioAnalyzeRMS">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAnalyzeFFT256">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Compute a 256 point Fast Fourier Transform (FFT) frequency analysis,
+		with real value (magnitude) output.  The frequency resolution is
+		172 Hz, useful for simple audio visualization.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to convert to frequency bins</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>available</span>();</p>
+	<p class=desc>Returns true each time the FFT analysis produces new output data.
+	</p>
+	<p class=func><span class=keyword>read</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin, from 0 to 127.  The result is scaled
+		so 1.0 represents a full scale sine wave.
+	</p>
+	<p class=func><span class=keyword>read</span>(firstBin, lastBin);</p>
+	<p class=desc>Read several frequency bins, returning their sum.  The higher
+		audio octaves are represented by many bins, which are typically read
+		as a group for audio visualization.
+	</p>
+	<p class=func><span class=keyword>averageTogether</span>(number);</p>
+	<p class=desc>New data is produced very radidly, approximately 344 times
+		per second.  Multiple outputs can be averaged together, so available()
+		returns true at a slower rate.
+	</p>
+	<p class=func><span class=keyword>windowFunction</span>(window);</p>
+	<p class=desc>Set the window function to be used.  AudioWindowHanning256
+		is the default.  Windowing may be disabled by NULL, but windowing
+		should be used for all non-periodic (music) signals, and all periodic
+		signals that are not exact integer division of the sample rate.
+	</p>
+
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; MemoryAndCpuUsage
+	</p>
+	<h3>Notes</h3>
+	<p>The raw 16 bit output data bins may be access with myFFT.output[num], where
+		num is 0 to 127.</p>
+	<p>TODO: caveats about spectral leakage vs frequency precision for arbitrary signals</p>
+	<p>Window Types:
+		<ul>
+		<li><span class=literal>AudioWindowHanning256</span> (default)</li>
+		<li><span class=literal>AudioWindowBartlett256</span></li>
+		<li><span class=literal>AudioWindowBlackman256</span></li>
+		<li><span class=literal>AudioWindowFlattop256</span></li>
+		<li><span class=literal>AudioWindowBlackmanHarris256</span></li>
+		<li><span class=literal>AudioWindowNuttall256</span></li>
+		<li><span class=literal>AudioWindowBlackmanNuttall256</span></li>
+		<li><span class=literal>AudioWindowWelch256</span></li>
+		<li><span class=literal>AudioWindowHamming256</span></li>
+		<li><span class=literal>AudioWindowCosine256</span></li>
+		<li><span class=literal>AudioWindowTukey256</span></li>
+		</ul>
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioAnalyzeFFT256">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAnalyzeFFT1024">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Compute a 1024 point Fast Fourier Transform (FFT) frequency analysis,
+		with real value (magnitude) output.  The frequency resolution is
+		43 Hz, useful detailed for audio visualization.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to convert to frequency bins</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>available</span>();</p>
+	<p class=desc>Returns true each time the FFT analysis produces new output data.
+	</p>
+	<p class=func><span class=keyword>read</span>(binNumber);</p>
+	<p class=desc>Read a single frequency bin, from 0 to 511.  The result is scaled
+		so 1.0 represents a full scale sine wave.
+	</p>
+	<p class=func><span class=keyword>read</span>(firstBin, lastBin);</p>
+	<p class=desc>Read several frequency bins, returning their sum.  The higher
+		audio octaves are represented by many bins, which are typically read
+		as a group for audio visualization.
+	</p>
+	<p class=func><span class=keyword>averageTogether</span>(number);</p>
+	<p class=desc>This function does nothing.  The 1024 point FFT always
+		updates at approximately 86 times per second.
+	</p>
+	<p class=func><span class=keyword>windowFunction</span>(window);</p>
+	<p class=desc>Set the window function to be used.  AudioWindowHanning1024
+		is the default.  Windowing may be disabled by NULL, but windowing
+		should be used for all non-periodic (music) signals, and all periodic
+		signals that are not exact integer division of the sample rate.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; FFT
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; SpectrumAnalyzerBasic
+	</p>
+	<h3>Notes</h3>
+	<p>The raw 16 bit output data bins may be access with myFFT.output[num], where
+		num is 0 to 511.</p>
+	<p>TODO: caveats about spectral leakage vs frequency precision for arbitrary signals</p>
+	<p>Window Types:
+		<ul>
+		<li><span class=literal>AudioWindowHanning1024</span> (default)</li>
+		<li><span class=literal>AudioWindowBartlett1024</span></li>
+		<li><span class=literal>AudioWindowBlackman1024</span></li>
+		<li><span class=literal>AudioWindowFlattop1024</span></li>
+		<li><span class=literal>AudioWindowBlackmanHarris1024</span></li>
+		<li><span class=literal>AudioWindowNuttall1024</span></li>
+		<li><span class=literal>AudioWindowBlackmanNuttall1024</span></li>
+		<li><span class=literal>AudioWindowWelch1024</span></li>
+		<li><span class=literal>AudioWindowHamming1024</span></li>
+		<li><span class=literal>AudioWindowCosine1024</span></li>
+		<li><span class=literal>AudioWindowTukey1024</span></li>
+		</ul>
+	</p>
+	<p>1024 point FFT has a peak CPU usage of approx 52% on Teensy 3.1.
+		Average usage is much lower.  Future versions might distribute the
+		load more evenly over time....
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioAnalyzeFFT1024">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAnalyzeToneDetect">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Detect the level of a single tone.</p>
+	<p>Uses the
+	<a href="https://en.wikipedia.org/wiki/Goertzel_algorithm" target="_blank">Goertzel algorithm</a>
+	.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to analyze</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>frequency</span>(freq);</p>
+	<p class=desc>Set the frequency to detect.  The default detection time
+		will be 10 cycles of this frequency.
+	</p>
+	<p class=func><span class=keyword>frequency</span>(freq, cycles);</p>
+	<p class=desc>Set the frequency to detect, and the number of cycles.
+		Longer detection time (more cycles) will give higher precision,
+		but of course slower response.
+	</p>
+	<p class=func><span class=keyword>available</span>();</p>
+	<p class=desc>Returns true (non-zero) each time a detection interval
+		(number of cycles) completed and a new level is detected.
+	</p>
+	<p class=func><span class=keyword>read</span>();</p>
+	<p class=desc>Read the detected signal level.  Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>threshold</span>(level);</p>
+	<p class=desc>Set a detection threshold, where the bool test operation
+		will return true if at or above this level, or false when below.
+	</p>
+	<p class=func>(bool)</p>
+	<p class=desc>By testing the object as a boolean value, you can respond
+		to detection of a tone.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; DialTone_Serial
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; DialTone_7segment
+	</p>
+	<h3>Notes</h3>
+	<p>Low frequency detection has trouble with numerical precision.
+		Works really well for all 8 DTMF frequencies, but fails for
+		detecting "sub audible tones" used in some control applications.</p>
+	<p>The (bool) test continues to return true until the next detection
+		interval (the configured number of cycles).  This behavior may
+		change in future versions, for a single true each time the signal
+		is detected, and then false for the remainder of that interval.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioAnalyzeToneDetect">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAnalyzeNoteFrequency">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Detect with fairly good accuracy the fundamental frequency f<sub>o</sub>
+		of musical notes, such as electric guitar and bass.</p>
+	</div>
+    <p>Written By Collin Duffy</p>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to analyze</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>begin</span>(threshold);</p>
+	<p class=desc>Initialize and start detecting frequencies,
+		with an initial threshold (the amount of allowed uncertainty).
+	</p>
+	<p class=func><span class=keyword>available</span>();</p>
+	<p class=desc>Returns true (non-zero) when a valid
+		frequency is detected.
+	</p>
+	<p class=func><span class=keyword>read</span>();</p>
+	<p class=desc>Read the detected frequency.
+	</p>
+	<p class=func><span class=keyword>probability</span>();</p>
+	<p class=desc>Return the level of certainty, betweeo 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>threshold</span>(level);</p>
+	<p class=desc>Set the detection threshold, the amount of allowed uncertainty.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; Analysis &gt; NoteFrequency
+	</p>
+	<h3>Notes</h3>
+	<p>The <a href="http://recherche.ircam.fr/equipes/pcm/cheveign/pss/2002_JASA_YIN.pdf">YIN algorithm</a> (PDF)
+		is used to detect frequencies, with many optimizations for
+		frequencies between 29-400Hz.  This algorithm can be somewhat
+		memory and processor hungry but will allow you to detect with
+		fairly good accuracy the fundamental frequencies from
+		electric guitars and basses.</p>
+	<p>Within the code, AUDIO_GUITARTUNER_BLOCKS
+		may be edited to control low frequency range.  The default
+		(24) allows measurement down to 29.14 Hz, or B(flat)0.</p>
+	<p>TODO: The usable upper range of this object is not well known.
+		Duff says "it should be good up to 1000Hz", but may have trouble
+		at 4 kHz.  Please <a href="https://forum.pjrc.com/threads/32252-Different-Range-FFT-Algorithm/page2">post feedback here</a>, ideally with audio clips for the NoteFrequency example.</p>
+	<p>This object was contributed by Collin Duffy from his
+		<a href="https://github.com/duff2013/AudioTuner">AudioTuner project</a>.
+		Additional details and documentation may be found there.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioAnalyzeNoteFrequency">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioAnalyzePrint">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Print raw audio data to the Arduino Serial Monitor.  This
+		object creates massive output quickly, and should not normally be used.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Signal to print</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>name</span>(string);</p>
+	<p class=desc>blah blah blah blah
+	</p>
+	<p class=func><span class=keyword>trigger</span>();</p>
+	<p class=desc>blah blah blah blah
+	</p>
+	<p class=func><span class=keyword>trigger</span>(level, edge);</p>
+	<p class=desc>blah blah blah blah
+	</p>
+	<p class=func><span class=keyword>delay</span>(samples);</p>
+	<p class=desc>blah blah blah blah
+	</p>
+	<p class=func><span class=keyword>length</span>(samples);</p>
+	<p class=desc>blah blah blah blah
+	</p>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p>This object doesn't work very well and probably should not be used.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioAnalyzePrint">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioControlSGTL5000">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Control the SGTL5000 chip on the
+		<a href="http://www.pjrc.com/store/teensy3_audio.html" target="_blank">audio shield</a>.
+		SGTL5000 is always used in slave mode, where Teensy controls
+		all I2S timing.
+	</p>
+	<p align=center><img src="img/sgtl5000closeup.jpg"></p>
+	</div>
+	<h3>Audio Connections</h3>
+	<p>This object has no audio inputs or outputs.  Separate i2s objects
+		are used to send and receive audio data.  I2S master mode objects
+		must be used, because this object configures the SGTL5000 in slave
+		mode, where it depends on Teensy to provide all I2S clocks.
+		This object controls
+		how the SGTL5000 will use those I2S audio streams.</p>
+
+	<h3>Functions</h3>
+	<p>These are the most commonly used SGTL5000 functions.</p>
+	<p class=func><span class=keyword>enable</span>();</p>
+	<p class=desc>Start the SGTL5000.  This function should be called first.
+	</p>
+	<p class=func><span class=keyword>volume</span>(level);</p>
+	<p class=desc>Set the headphone volume level.  Range is 0 to 1.0, but
+		0.8 corresponds to the maximum undistorted output for a full scale
+		signal.  Usually 0.5 is a comfortable listening level.  The line
+		level outputs are <em>not</em> changed by this function.
+	</p>
+	<p class=func><span class=keyword>inputSelect</span>(input);</p>
+	<p class=desc>Select which input to use: AUDIO_INPUT_LINEIN or AUDIO_INPUT_MIC.
+	</p>
+	<p class=func><span class=keyword>micGain</span>(dB);</p>
+	<p class=desc>When using the microphone input, set the amplifier gain.
+		The input number is in decibels, from 0 to 63.
+	</p>
+
+	<h3>Signal Levels</h3>
+
+	<p>The default signal levels should be used for most applications,
+		but these functions allow you to customize the analog signals.</p>
+
+	<p class=func><span class=keyword>muteHeadphone</span>();</p>
+	<p class=desc>Silence the headphone output.
+	</p>
+	<p class=func><span class=keyword>unmuteHeadphone</span>();</p>
+	<p class=desc>Turn the headphone output on.
+	</p>
+	<p class=func><span class=keyword>muteLineout</span>();</p>
+	<p class=desc>Silence the line level outputs.
+	</p>
+	<p class=func><span class=keyword>unmuteLineout</span>();</p>
+	<p class=desc>Turn the line level outputs on.
+	</p>
+	<p class=func><span class=keyword>lineInLevel</span>(both);</p>
+	<p class=desc style="padding-bottom:0.2em;">Adjust the sensitivity of the line-level inputs.
+		Fifteen settings are possible:
+	</p>
+<pre class="desc">
+ 0: 3.12 Volts p-p
+ 1: 2.63 Volts p-p
+ 2: 2.22 Volts p-p
+ 3: 1.87 Volts p-p
+ 4: 1.58 Volts p-p
+ 5: 1.33 Volts p-p  (default)
+ 6: 1.11 Volts p-p
+ 7: 0.94 Volts p-p
+ 8: 0.79 Volts p-p
+ 9: 0.67 Volts p-p
+10: 0.56 Volts p-p
+11: 0.48 Volts p-p
+12: 0.40 Volts p-p
+13: 0.34 Volts p-p
+14: 0.29 Volts p-p
+15: 0.24 Volts p-p
+</pre>
+	<p class=func><span class=keyword>lineInLevel</span>(right, left);</p>
+	<p class=desc>Adjust the sensitivity of the line-level inputs, with different
+		settings for left and right.  The same 15 settings are available.
+	</p>
+	<p class=func><span class=keyword>lineOutLevel</span>(both);</p>
+	<p class=desc style="padding-bottom:0.2em;">Adjust the line level output
+		voltage range.  The following settings are possible:
+	</p>
+<pre class="desc">
+13: 3.16 Volts p-p
+14: 2.98 Volts p-p
+15: 2.83 Volts p-p
+16: 2.67 Volts p-p
+17: 2.53 Volts p-p
+18: 2.39 Volts p-p
+19: 2.26 Volts p-p
+20: 2.14 Volts p-p
+21: 2.02 Volts p-p
+22: 1.91 Volts p-p
+23: 1.80 Volts p-p
+24: 1.71 Volts p-p
+25: 1.62 Volts p-p
+26: 1.53 Volts p-p
+27: 1.44 Volts p-p
+28: 1.37 Volts p-p
+29: 1.29 Volts p-p  (default)
+30: 1.22 Volts p-p
+31: 1.16 Volts p-p
+</pre>
+	<p class=func><span class=keyword>lineOutLevel</span>(left, right);</p>
+	<p class=desc>Adjust the line level outout voltage range, with separate
+		settings for left and right.  The same settings (13 to 31) are available.
+	</p>
+
+
+	<h3>Signal Conditioning</h3>
+
+	<p>Usually these digital signal conditioning features should be left at their
+		default settings.
+	</p>
+
+	<p class=func><span class=keyword>adcHighPassFilterFreeze</span>();</p>
+	<p class=desc>By default, the analog input (either line-level inputs or mic)
+		is high-pass filtered, to remove any DC component.  This function
+		freezes the filter, so the current DC component is still substracted, but
+		the filter stops tracking any DC or low frequency changes.
+	</p>
+	<p class=func><span class=keyword>adcHighPassFilterDisable</span>();</p>
+	<p class=desc>Completely disable the analog input filter.  DC and sub-audible
+		low frequencies are allowed to enter the digital signal.  This
+		<a href="http://openaudio.blogspot.com/2017/03/teensy-audio-board-self-noise.html">may
+		reduce noise</a> in some cases.
+	</p>
+	<p class=func><span class=keyword>adcHighPassFilterEnable</span>();</p>
+	<p class=desc>Turn the DC-blocking filter back on, if disabled, or
+		allows it to resume tracking DC and low frequency changes, if
+		previously frozen. This is the default setting.
+	</p>
+	<p class=func><span class=keyword>dacVolume</span>(both);</p>
+	<p class=desc>Normally output volume should be used with volume(), which
+		changes the analog gain in the headphone amplifier.  This function
+		on the other hand controls digital attenuation before conversion to analog, which
+		reduces resolution, but allows another fine control of output
+		signal level.  The ranges is 0 to 1.0, with the default (no digital attenuation)
+		at 1.0.
+	</p>
+	<p  class=desc>dacVolume uses zero-crossing detect to avoid clicks, and graceful
+		ramping is handled by the chip so that a new volume may be set directly in
+		a single call.
+	</p>
+	<p class=func><span class=keyword>dacVolume</span>(left, right);</p>
+	<p class=desc>Adjust the digital output volume separately on left and
+		right channels.
+	</p>
+	<p class=func><span class=keyword>dacVolumeRamp</span>();</p>
+	<p class=desc>Enable graceful volume ramping.  The dacVolume adjusts gradually using
+		an exponential curve.  Pops or loud clicks are avoided when making large
+		changes in volume level.
+	</p>
+	<p class=func><span class=keyword>dacVolumeRampLinear</span>();</p>
+	<p class=desc>Enable faster volume ramping.  A slight click may be heard during a
+		large volume change.
+	</p>
+	<p class=func><span class=keyword>dacVolumeRampDisable</span>();</p>
+	<p class=desc>Do not use any gradual ramping.  The zero cross feature still helps
+		for small changes, but large volume changes may produce a pop or click.
+	</p>
+
+	<h3>Audio Processor</h3>
+
+	<p>The optional digital audio processor is capable of implementing
+		one or more of: automatic volume control, surround sound control,
+		bass enhancement, and tonal adjustments (either a
+		simple tone control, or a parametric equalizer, or a graphic equalizer),
+		in that order.
+	</p>
+	<p>These signal processing features are implemented in the SGTL5000 chip,
+		so they do not consume CPU time on Teensy. However, the order of
+		these processes is fixed in the hardware.
+	</p>
+	<p>It is good practice to mute the outputs before enabling or disabling
+	the Audio Processor, to avoid clicks or thumps.
+	</p>
+
+	<p class=func><span class=keyword>audioPreProcessorEnable</span>();</p>
+	<p class=desc>Enable the audio processor to pre-process the input
+		(from either line-level inputs or microphone) before it's sent
+		to Teensy by I2S.
+	</p>
+	<p class=func><span class=keyword>audioPostProcessorEnable</span>();</p>
+	<p class=desc>Enable the audio processor to post-process Teensy's
+		I2S output before it's turned into analog signals for the
+		headphones and/or line level outputs.
+	</p>
+	<p class=func><span class=keyword>audioProcessorDisable</span>();</p>
+	<p class=desc>Disable the audio processor.
+	</p>
+	<p class=func><span class=keyword>autoVolumeControl</span>(maxGain, response, hardLimit, threshold, attack, decay);</p>
+	<p class=desc>Configures the auto volume control, which is implemented as a compressor/expander
+	or hard limiter. 	<em>maxGain</em> is the maximum gain that can be applied for expanding, and
+	can take one of three values: 0 (0dB), 1 (6.0dB) and 2 (12dB). Values greater than 2 are treated
+	as 2. <em>response</em> controls the integration time for the compressor and can take
+	four values: 0 (0ms), 1 (25ms), 2 (50ms) or 3 (100ms). Larger values average the volume
+	over a longer time, allowing short-term peaks through.
+	</p>
+	<p class=desc>If <em>hardLimit</em> is 0, a 'soft
+	knee' compressor is used to progressively compress louder values which are near to or above the
+	threashold (the louder they are, the greater the compression). If it is 1, a hard compressor
+	is used (all values above the threashold are the same loudness). The <em>threashold</em> is specified
+	as a float in the range 0dBFS to -96dBFS, where -18dBFS is a typical value.
+	<em>attack</em> is a float controlling the rate of decrease in gain when the signal is over
+	threashold, in dB/s. <em>decay</em> controls how fast gain is restored once the level
+	drops below threashold, again in dB/s. It is typically set to a longer value than attack.
+	</p>
+	<p class=func><span class=keyword>autoVolumeEnable</span>();</p>
+	<p class=desc>Enables auto volume control, using the previously specified settings.
+	</p>
+	<p class=func><span class=keyword>autoVolumeDisable</span>();</p>
+	<p class=desc>Disables auto volume control.
+	</p>
+
+	<p class=func><span class=keyword>surroundSoundEnable</span>();</p>
+	<p class=desc>Enable virtual surround processing, to give a broader and
+	deeper stereo image (even with mono input).
+	</p>
+	<p class=func><span class=keyword>surroundSoundDisable</span>();</p>
+	<p class=desc>Disable virtual surround processing. Before disabling, ramp up
+	the width to maximum to avoid pops.
+	</p>
+	<p class=func><span class=keyword>surroundSound</span>(width);</p>
+	<p class=desc>Configures virtual surround width from 0 (mono) to 7 (widest).
+	</p>
+	<p class=func><span class=keyword>surroundSound</span>(width, select);</p>
+	<p class=desc>Configures virtual surround width from 0 (mono) to 7 (widest).
+	<em>select</em> may be set to 1 (disable), 2 (mono input) or 3 (stereo input).
+	</p>
+
+	<p class=func><span class=keyword>enhanceBassEnable</span>();</p>
+	<p class=desc>Enable bass enhancement. A mono, low-pass filtered copy of
+	the original stereo signal has bass levels boosted and is then mixed back into
+	the stereo signal, which is then optionally high pass filtered (to remove
+	inaudible subsonic frequencies).
+	</p>
+	<p class=func><span class=keyword>enhanceBassDisable</span>();</p>
+	<p class=desc>Disable bass enhancement. Before disabling, ramp down the bass
+	enhancement level to zero.
+	</p>
+	<p class=func><span class=keyword>enhanceBass</span>(lr_lev, bass_lev);</p>
+	<p class=desc>Configures the bass enhancement by setting the levels of the
+	original stereo signal and the bass-enhanced mono level which will be mixed together.
+	There is no high-pass filter.
+	</p>
+	<p  class=desc>When changing bass level, call this function repeatedly to ramp up or down the bass in
+	steps of 0.5dB, to avoid pops.
+	</p>
+	<p class=func><span class=keyword>enhanceBass</span>(lr_lev, bass_lev, hpf_bypass, cutoff);</p>
+	<p class=desc>Configures the bass enhancement by setting the levels of the
+	original stereo signal and the bass-enhanced mono level which will be mixed together.
+	The high-pass filter may be enabled (0) or bypassed (1). The cutoff frequency is specified
+	as follows:
+	</p>
+	<pre class="desc">
+value  frequency
+ 0      80Hz
+ 1     100Hz
+ 2     125Hz
+ 3     150Hz
+ 4     175Hz
+ 5     200Hz
+ 6     225Hz
+</pre>
+	<p  class=desc>When changing bass level, call this function repeatedly to ramp up or down the bass in
+	steps of 0.5dB, to avoid pops.
+	</p>
+
+	<p class=func><span class=keyword>eqSelect</span>(n);</p>
+	<p class=desc>Selects the type of frequency control, where <em>n</em> is
+	one of</p>
+	<p class=desc><b>FLAT_FREQUENCY (0)</b><br>
+    Equalizers and tone controls disabled, flat frequency response.</p>
+    <p class=desc><b>PARAMETRIC_EQUALIZER (1)</b><br>
+    Enables the 7-band parametric equalizer, thus disabling the
+	tone controls and graphic equalizer.</p>
+    <p class=desc><b>TONE_CONTROLS (2)</b><br>
+    Enables bass and treble tone controls, disabling the parametric
+	equalization and graphic equalizer.</p>
+    <p class=desc><b>GRAPHIC_EQUALIZER (3)</b><br>
+    Enables the five-band graphic equalizer, disabling the parametric
+	equalization and tone controls.</p>
+
+
+	<p class=func><span class=keyword>eqBands</span>(bass, treble);</p>
+	<p class=desc>Configures bass and treble tone controls, which are
+	implemented as one second order low pass filter (bass) in parallel with
+	one second order high pass filter (treble).
+	</p>
+	<p class=desc>When changing bass or treble level, call this function repeatedly to ramp
+	up or down the level in steps of 0.04 (=0.5dB) or so, to avoid pops.
+	</p>
+	<p class=func><span class=keyword>eqBands</span>(bass, mid_bass, midrange, mid_treble, treble);</p>
+	<p class=desc>Configures the graphic equalizer. It is implemented by five parallel,
+	second order biquad filters with fixed frequencies of 115Hz, 330Hz, 990Hz, 3kHz,
+	and 9.9kHz. Each band has a range of adjustment from 1.00 (+12dB) to -1.00 (-11.75dB).
+	</p>
+	<p class=func><span class=keyword>eqBand</span>(bandNum, n);</p>
+	<p class=desc>Configures the gain or cut on one band in the graphic equalizer.
+	<em>bandnum</em> can range from 1 to 5; <em>n</em> is a float in the range 1.00 to -1.00.
+	</p>
+	<p  class=desc>When changing a band, call this function repeatedly to ramp up the gain in steps of 0.5dB,
+	to avoid pops.
+	</p>
+
+	<p class=func><span class=keyword>eqFilter</span>(filterNum, filterParameters);</p>
+	<p class=desc>Configurs the parametric equalizer. The number of filters (1 to 7)
+	is specified along with  a pointer to an array of filter coefficients.
+	The parametric equalizer is implemented using 7 cascaded, second order bi-quad
+	filters whose frequencies, gain, and Q may be freely configured, but each filter
+	can only be specified as a set of filter coefficients.
+	</p>
+	<p class=func><span class=keyword>eqFilterCount</span>(n);</p>
+	<p class=desc>Enables zero or more of the already enabled parametric filters.
+	</p>
+
+	<h3>Examples</h3>
+	<p>Nearly all of the library's examples use this object.  These
+		examples demonstrate its special features.
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; PassThroughStereo
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; SGTL5000 &gt; dap_bass_enhance
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; SGTL5000 &gt; dap_avc_agc
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; SGTL5000 &gt; balanceDAC
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; SGTL5000 &gt; balanceHP
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; SGTL5000 &gt; CalcBiquadToneControlDAP
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; SGTL5000 &gt; VolumeRamp
+	</p>
+	<h3>Notes</h3>
+	<p>TODO: add example with rock/classical/speech presets, where rock uses bass boost
+	and surround enhancement while speech uses bandpass filtering and auto volume control
+	compression.
+	</p>
+	<p>TODO: add example with two analogRead pots for bass and treble to demonstrate ramping.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioControlSGTL5000">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioControlWM8731">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Control a WM8731 chip in slave mode, where it receives all clocks from Teensy</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<p>This object has no audio inputs or outputs.  Separate i2s objects
+		are used to send and receive audio data.  I2S master mode objects
+		must be used, since this control object configures the WM8731 into
+		slave mode.
+	</p>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>enable</span>();</p>
+	<p class=desc>Turn on the WS8731.
+	</p>
+	<p class=func><span class=keyword>disable</span>();</p>
+	<p class=desc>not implemented
+	</p>
+	<p class=func><span class=keyword>volume</span>(level);</p>
+	<p class=desc>Set the headphone volume level. Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>inputLevel</span>(level);</p>
+	<p class=desc>Adjust the line level input gain.  Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>inputSelect</span>(input);</p>
+	<p class=desc>Select which input to use: AUDIO_INPUT_LINEIN or AUDIO_INPUT_MIC.
+	</p>
+	<!--
+<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt;
+	</p>
+-->
+	<h3>Notes</h3>
+	<p></p>
+</script>
+<script type="text/x-red" data-template-name="AudioControlWM8731">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioControlWM8731master">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Control a WM8731 chip in master mode, where it controls all I2S timing.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<p>This object has no audio inputs or outputs.  Separate i2s objects
+		are used to send and receive audio data.  I2S slave mode objects
+		must be used, since this control object configures the WM8731 into
+		master mode.
+	</p>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>enable</span>();</p>
+	<p class=desc>Turn on the WS8731, in I2S Master mode.  I2S slave mode
+		communication must be used by Teensy.
+	</p>
+	<p class=func><span class=keyword>disable</span>();</p>
+	<p class=desc>not implemented
+	</p>
+	<p class=func><span class=keyword>volume</span>(level);</p>
+	<p class=desc>Set the headphone volume level. Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>inputLevel</span>(level);</p>
+	<p class=desc>Adjust the line level input gain.  Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>inputSelect</span>(input);</p>
+	<p class=desc>Select which input to use: AUDIO_INPUT_LINEIN or AUDIO_INPUT_MIC.
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; WM8731MikroSine
+	</p>
+	<h3>Notes</h3>
+	<p>The WM8731 will implement a sample rate of its crystal frequency divided by 256.
+		To get the 44.1 kHz sample rate the Teensy Audio Library expects, an
+		11.2896 MHz crystal should be used.
+	</p>
+</script>
+<script type="text/x-red" data-template-name="AudioControlWM8731master">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioControlAK4558">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Control the AK4558 chip on the <a href="https://hackaday.io/project/8567-hifi-audio-codec-module" target="_blank">HiFi Audio CODEC Module</a>
+	in slave mode, where the Teensy controls all I2S timing.</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<p>This object has no audio inputs or outputs.  Separate I2S objects
+		are used to send and receive audio data.
+	</p>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>enable</span>();</p>
+	<p class=desc>Enables the CODEC to work with 44.1 KHz - 16 bit data. This function does not enable the ADC/DAC modules.
+	</p>
+	<p class=func><span class=keyword>enableIn</span>();</p>
+	<p class=desc>Enables the ADC module.
+	</p>
+	<p class=func><span class=keyword>enableOut</span>();</p>
+	<p class=desc>Enables the DAC module.
+	</p>
+	<p class=func><span class=keyword>disable</span>();</p>
+	<p class=desc>Disables the ADC and the DAC modules.
+	</p>
+	<p class=func><span class=keyword>disableIn</span>();</p>
+	<p class=desc>Disable the ADC module.
+	</p>
+	<p class=func><span class=keyword>disableOut</span>();</p>
+	<p class=desc>Disable the DAC module.
+	</p>
+	<p class=func><span class=keyword>volume</span>(level);</p>
+	<p class=desc>Accepts a float in range 0.0-1.0 and sets the line output volume accordingly.
+	</p>
+	<p class=func><span class=keyword>volumeLeft</span>(level);</p>
+	<p class=desc>Accepts a float in range 0.0-1.0 and sets the left line output volume accordingly.
+	</p>
+	<p class=func><span class=keyword>volumeRight</span>(level);</p>
+	<p class=desc>Accepts a float in range 0.0-1.0 and sets the right line output volume accordingly.
+	</p>
+	<p class=func><span class=keyword>inputLevel</span>(level);</p>
+	<p class=desc>NOT SUPPORTED BY THE AK4558
+	</p>
+	<p class=func><span class=keyword>inputSelect</span>(input);</p>
+	<p class=desc>not implemented yet
+	</p>
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; AK4558 &gt; PassthroughTest
+	</p>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; AK4558 &gt; SineOutTest
+	</p>
+	<h3>Notes</h3>
+	<p>TODO: Implement inputSelect() function to enable mono left, mono right, stereo operation.</p>
+	<p>TODO: Implement ADC and DAC filters control.</p>
+	<p>TODO: Implement DAC level attenuator attack rate modifier.</p>
+</script>
+<script type="text/x-red" data-template-name="AudioControlAK4558">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioControlCS4272">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Control the CS4272 chip on the <a href="https://hackaday.io/project/5912-teensy-super-audio-board" target="_blank">Super Audio Board</a>.
+	</p>
+	<p>TODO: does this control object put the CS4272 into I2S master or slave mode</p>
+	</div>
+	<h3>Audio Connections</h3>
+	<p>This object has no audio inputs or outputs.  Separate I2S objects
+		are used to send and receive audio data.
+	</p>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>enable</span>();</p>
+	<p class=desc>Enables the CODEC to work with 44.1 KHz - 16 bit data. This function does not enable the ADC/DAC modules.
+	</p>
+	<p class=func><span class=keyword>volume</span>(vol);</p>
+	<p class=desc>Set the volume level. Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>volume</span>(left, right);</p>
+	<p class=desc>Set the volume level. Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>dacVolume</span>(vol);</p>
+	<p class=desc>Set the volume level. Range is 0 to 1.0.  TODO: what's the
+		distinction between volume() and dacVolume()?
+	</p>
+	<p class=func><span class=keyword>dacVolume</span>(left, right);</p>
+	<p class=desc>Set the volume level. Range is 0 to 1.0.
+	</p>
+
+	<p class=func><span class=keyword>muteOutput</span>();</p>
+	<p class=desc>TODO: description
+	</p>
+	<p class=func><span class=keyword>unmuteOutput</span>();</p>
+	<p class=desc>TODO: description
+	</p>
+	<p class=func><span class=keyword>muteInput</span>();</p>
+	<p class=desc>TODO: description
+	</p>
+	<p class=func><span class=keyword>unmuteInput</span>();</p>
+	<p class=desc>TODO: description
+	</p>
+	<p class=func><span class=keyword>enableDither</span>();</p>
+	<p class=desc>TODO: description
+	</p>
+	<p class=func><span class=keyword>disableDither</span>();</p>
+	<p class=desc>TODO: description
+	</p>
+
+	<h3>Hardware</h3>
+	<p>Pin 2 must be connected to the CS4272 reset.  SDA &amp; SCL are used for all control.
+	</p>
+
+	<h3>Notes</h3>
+</script>
+<script type="text/x-red" data-template-name="AudioControlCS4272">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<script type="text/x-red" data-help-name="AudioControlCS42448">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Control the CS42448 chip in TDM mode, for 6 inputs and 8 outputs.
+	</p>
+	<p align=center><img src="img/cs42448.jpg"></p>
+	</div>
+	</div>
+	<h3>Audio Connections</h3>
+	<p>This object has no audio inputs or outputs.  Separate TDM objects
+		are used to send and receive audio data.
+	</p>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>enable</span>();</p>
+	<p class=desc>Enables the CS42448 to work in TDM mode.
+	</p>
+	<p class=func><span class=keyword>volume</span>(level);</p>
+	<p class=desc>Set the volume level for all output channels. Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>volume</span>(channel, level);</p>
+	<p class=desc>Set the volume level for a single output. Channel is 1 to 8.  Range is 0 to 1.0.
+	</p>
+	<p class=func><span class=keyword>inputLevel</span>(level);</p>
+	<p class=desc>Set the input gain level for all input channels. Range is 0 to 15.85.
+	</p>
+	<p class=func><span class=keyword>inputLevel</span>(channel, level);</p>
+	<p class=desc>Set the input gain level for a single input. Channel is 1 to 6. Range is 0 to 15.85.
+	</p>
+	<h3>Hardware</h3>
+	<p>Tested with this <a href="https://oshpark.com/shared_projects/2Yj6rFaW">
+		CS42448 Board for Teensy 3.x</a> and this
+		<a href="https://oshpark.com/shared_projects/gVFy0fWQ">
+		CS42448 Board for Teensy 4.x</a>.
+	</p>
+	<p align=center><img src="img/tdm.jpg"></p>
+	</div>
+	<h3>Notes</h3>
+</script>
+<script type="text/x-red" data-template-name="AudioControlCS42448">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+
+
+</body>
+</html>

--- a/changedGUI/index.html
+++ b/changedGUI/index.html
@@ -392,6 +392,9 @@ span.mainfunction {color: #993300; font-weight: bolder}
 		{"type":"AudioInputTDM2",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
 		{"type":"AudioInputTDM2",        "resource":"IN2 Pin",       "shareable":false},
 		{"type":"AudioInputUSB",         "resource":"USB Rx Endpoint","shareable":false},
+		{"type":"AudioInputUSBQuad",         "resource":"USB Rx Endpoint","shareable":false},
+		{"type":"AudioInputUSBHex",         "resource":"USB Rx Endpoint","shareable":false},
+		{"type":"AudioInputUSBOct",         "resource":"USB Rx Endpoint","shareable":false},
 		{"type":"AudioOutputI2S",        "resource":"I2S Device",    "shareable":true,  "setting":"I2S Master"},
 		{"type":"AudioOutputI2S",        "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
 		{"type":"AudioOutputI2S",        "resource":"OUT1A Pin",     "shareable":false},
@@ -449,7 +452,10 @@ span.mainfunction {color: #993300; font-weight: bolder}
 		{"type":"AudioOutputADAT",       "resource":"I2S Device",    "shareable":true,  "setting":"ADAT Protocol"},
 		{"type":"AudioOutputADAT",       "resource":"Sample Rate",   "shareable":true,  "setting":"Teensy Control"},
 		{"type":"AudioOutputADAT",       "resource":"OUT1A Pin",     "shareable":false},
-		{"type":"AudioOutputUSB",        "resource":"USB Tx Endpoint","shareable":false}
+		{"type":"AudioOutputUSB",        "resource":"USB Tx Endpoint","shareable":false},
+		{"type":"AudioOutputUSBQuad",    "resource":"USB Tx Endpoint","shareable":false},
+		{"type":"AudioOutputUSBHex",     "resource":"USB Tx Endpoint","shareable":false},
+		{"type":"AudioOutputUSBOct",     "resource":"USB Tx Endpoint","shareable":false}
 	]}
 </script>
 
@@ -471,6 +477,9 @@ span.mainfunction {color: #993300; font-weight: bolder}
 		{"type":"AudioInputTDM","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm","inputs":0,"outputs":16,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioInputTDM2","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm2","inputs":0,"outputs":16,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioInputUSB","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb","inputs":0,"outputs":2,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputUSBQuad","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb_quad","inputs":0,"outputs":4,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputUSBHex","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb_hex","inputs":0,"outputs":6,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioInputUSBOct","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb_oct","inputs":0,"outputs":8,"category":"input-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 
 		{"type":"AudioOutputI2S","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioOutputI2SQuad","data":{"defaults":{"name":{"value":"new"}},"shortName":"i2s_quad","inputs":4,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
@@ -491,6 +500,9 @@ span.mainfunction {color: #993300; font-weight: bolder}
 		{"type":"AudioOutputTDM2","data":{"defaults":{"name":{"value":"new"}},"shortName":"tdm2","inputs":16,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioOutputADAT","data":{"defaults":{"name":{"value":"new"}},"shortName":"adat","inputs":8,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioOutputUSB","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb","inputs":2,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputUSBQuad","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb_quad","inputs":4,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputUSBHex","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb_hex","inputs":6,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
+		{"type":"AudioOutputUSBOct","data":{"defaults":{"name":{"value":"new"}},"shortName":"usb_oct","inputs":8,"outputs":0,"category":"output-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 
 		{"type":"AudioAmplifier","data":{"defaults":{"name":{"value":"new"}},"shortName":"amp","inputs":1,"outputs":1,"category":"mixer-function","color":"#E6E0F8","icon":"arrow-in.png"}},
 		{"type":"AudioMixer4","data":{"defaults":{"name":{"value":"new"}},"shortName":"mixer","inputs":4,"outputs":1,"category":"mixer-function","color":"#E6E0F8","icon":"arrow-in.png"}},
@@ -1492,6 +1504,165 @@ Returns the actual achieved attenuation of the anti-aliasing filter. If the inpu
 		<input type="text" id="node-input-name" placeholder="Name">
 	</div>
 </script>
+
+<!-- ------------------------------------------------------------------------------------------------------------>
+<script type="text/x-red" data-help-name="AudioInputUSBQuad">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 4-channel audio from a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_in.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Channel 0</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Channel 1</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Channel 2</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Channel 3</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>volume</span>();</p>
+	<p class=desc>Returns the volume setting requested by the USB host.
+		Range is 0 to 1.0.  To make the PC's volume control work, this
+		setting should be read periodically and used to control the
+		system processing the signal.
+	</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>TBD</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+</script>
+
+<script type="text/x-red" data-template-name="AudioInputUSBQuad">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+<!-- ------------------------------------------------------------------------------------------------------------>
+
+<!-- ------------------------------------------------------------------------------------------------------------>
+<script type="text/x-red" data-help-name="AudioInputUSBHex">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 6-channel audio from a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_in.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Channel 0</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Channel 1</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Channel 2</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Channel 3</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Channel 4</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Channel 5</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>volume</span>();</p>
+	<p class=desc>Returns the volume setting requested by the USB host.
+		Range is 0 to 1.0.  To make the PC's volume control work, this
+		setting should be read periodically and used to control the
+		system processing the signal.
+	</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>TBD</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+</script>
+
+<script type="text/x-red" data-template-name="AudioInputUSBHex">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<!-- ------------------------------------------------------------------------------------------------------------>
+<script type="text/x-red" data-help-name="AudioInputUSBOct">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Receive 8-channel audio from a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_in.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>Out 0</td><td>Channel 0</td></tr>
+		<tr class=odd><td align=center>Out 1</td><td>Channel 1</td></tr>
+		<tr class=odd><td align=center>Out 2</td><td>Channel 2</td></tr>
+		<tr class=odd><td align=center>Out 3</td><td>Channel 3</td></tr>
+		<tr class=odd><td align=center>Out 4</td><td>Channel 4</td></tr>
+		<tr class=odd><td align=center>Out 5</td><td>Channel 5</td></tr>
+		<tr class=odd><td align=center>Out 6</td><td>Channel 6</td></tr>
+		<tr class=odd><td align=center>Out 7</td><td>Channel 7</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p class=func><span class=keyword>volume</span>();</p>
+	<p class=desc>Returns the volume setting requested by the USB host.
+		Range is 0 to 1.0.  To make the PC's volume control work, this
+		setting should be read periodically and used to control the
+		system processing the signal.
+	</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>TBD</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+</script>
+
+<script type="text/x-red" data-template-name="AudioInputUSBOct">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+<!-- ------------------------------------------------------------------------------------------------------------>
+
 
 <script type="text/x-red" data-help-name="AudioOutputI2S">
 	<h3>Summary</h3>
@@ -2534,6 +2705,163 @@ Returns the actual achieved attenuation of the anti-aliasing filter. If the inpu
 		<input type="text" id="node-input-name" placeholder="Name">
 	</div>
 </script>
+<!-- ------------------------------------------------------------------------------------------------------------>
+
+<script type="text/x-red" data-help-name="AudioOutputUSBQuad">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Send 4-channel audio to a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_out.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Channel 0</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Channel 1</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Channel 2</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Channel 3</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams from its 4 input ports to the USB.</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>TBD</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+	<p>A known problem exists with USB audio from Macintosh computers.
+		An imperfect <a href="https://forum.pjrc.com/threads/34855-Distorted-audio-when-using-USB-input-on-Teensy-3-1?p=110392&viewfull=1#post110392">workaround
+		can be enabled by editing usb_audio.cpp</a>.
+		Find and uncomment "#define MACOSX_ADAPTIVE_LIMIT".</p>
+</script>
+
+<script type="text/x-red" data-template-name="AudioOutputUSBQuad">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<!-- ------------------------------------------------------------------------------------------------------------>
+<script type="text/x-red" data-help-name="AudioOutputUSBHex">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Send 6-channel audio to a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_out.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Channel 0</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Channel 1</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Channel 2</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Channel 3</td></tr>
+		<tr class=odd><td align=center>In 4</td><td>Channel 4</td></tr>
+		<tr class=odd><td align=center>In 5</td><td>Channel 5</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams from its 6 input ports to the USB.</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; WavFilePlayerUSB</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+	<p>A known problem exists with USB audio from Macintosh computers.
+		An imperfect <a href="https://forum.pjrc.com/threads/34855-Distorted-audio-when-using-USB-input-on-Teensy-3-1?p=110392&viewfull=1#post110392">workaround
+		can be enabled by editing usb_audio.cpp</a>.
+		Find and uncomment "#define MACOSX_ADAPTIVE_LIMIT".</p>
+</script>
+
+<script type="text/x-red" data-template-name="AudioOutputUSBHex">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+
+<!-- ------------------------------------------------------------------------------------------------------------>
+<script type="text/x-red" data-help-name="AudioOutputUSBOct">
+	<h3>Summary</h3>
+	<div class=tooltipinfo>
+	<p>Send 8-channel audio to a PC or Mac.  Teensy appears as a USB
+		sound device.</p>
+	<p align=center><img src="img/usbtype_audio_out.png"></p>
+	</div>
+	<h3>Boards Supported</h3>
+	<ul>
+	<li>Teensy 4.0
+	<li>Teensy 4.1
+	</ul>
+	<h3>Audio Connections</h3>
+	<table class=doc align=center cellpadding=3>
+		<tr class=top><th>Port</th><th>Purpose</th></tr>
+		<tr class=odd><td align=center>In 0</td><td>Channel 0</td></tr>
+		<tr class=odd><td align=center>In 1</td><td>Channel 1</td></tr>
+		<tr class=odd><td align=center>In 2</td><td>Channel 2</td></tr>
+		<tr class=odd><td align=center>In 3</td><td>Channel 3</td></tr>
+		<tr class=odd><td align=center>In 4</td><td>Channel 4</td></tr>
+		<tr class=odd><td align=center>In 5</td><td>Channel 5</td></tr>
+		<tr class=odd><td align=center>In 6</td><td>Channel 6</td></tr>
+		<tr class=odd><td align=center>In 7</td><td>Channel 7</td></tr>
+	</table>
+	<h3>Functions</h3>
+	<p>This object has no functions to call from the Arduino sketch.  It
+		simply streams from its 8 input ports to the USB.</p>
+	<!--
+	<h3>Hardware</h3>
+	-->
+	<h3>Examples</h3>
+	<p class=exam>File &gt; Examples &gt; Audio &gt; HardwareTesting &gt; WavFilePlayerUSB</p>
+	</p>
+	<h3>Notes</h3>
+	<p>Arduino's <b>Tools &gt; USB Type</b> menu must be set to <b>Audio</b>.
+		</p>
+	<p align=center><img src="img/usbtype_audio.png"></p>
+	<p>USB input &amp; output does not cause the Teensy Audio Library to
+		update.  At least one non-USB input or output object must be
+		present for the entire library to update properly.</p>
+	<p>A known problem exists with USB audio from Macintosh computers.
+		An imperfect <a href="https://forum.pjrc.com/threads/34855-Distorted-audio-when-using-USB-input-on-Teensy-3-1?p=110392&viewfull=1#post110392">workaround
+		can be enabled by editing usb_audio.cpp</a>.
+		Find and uncomment "#define MACOSX_ADAPTIVE_LIMIT".</p>
+</script>
+
+<script type="text/x-red" data-template-name="AudioOutputUSBOct">
+	<div class="form-row">
+		<label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+</script>
+<!-- ------------------------------------------------------------------------------------------------------------>
 
 <script type="text/x-red" data-help-name="AudioAmplifier">
 	<h3>Summary</h3>

--- a/src/USBmultiChannelTest/USBmultiChannelTest.ino
+++ b/src/USBmultiChannelTest/USBmultiChannelTest.ino
@@ -1,0 +1,129 @@
+/*
+ * Testbed sketch for multi-channel USB audio
+ */
+#include <Audio.h>
+
+#define AUDIO_kHz ((int) AUDIO_SAMPLE_RATE / 1000)
+#define AUDIO_CHANNELS USB_AUDIO_NO_CHANNELS_480
+
+// Changing string in descriptor keeps Windows 10 happier
+extern "C"
+{
+    struct usb_string_descriptor_struct
+    {
+        uint8_t bLength;
+        uint8_t bDescriptorType;
+        uint16_t wString[6+1+1+2+1];
+    };
+    
+  usb_string_descriptor_struct usb_string_serial_number={
+    2+(6+1+1+2+1)*2,3,
+    {'A','u','d','i','o','-','0'+AUDIO_CHANNELS,'/','0'+(AUDIO_kHz / 10),'0' + (AUDIO_kHz % 10),'B'}
+  };
+}
+
+// GUItool: begin automatically generated code
+AudioSynthWaveform       wav1; //xy=479,580
+AudioSynthWaveform       wav2;      //xy=484,616
+AudioSynthWaveform       wav3; //xy=486,654
+AudioSynthWaveform       wav4; //xy=490,691
+AudioSynthWaveform       wav5; //xy=494,729
+AudioSynthWaveform       wav6; //xy=499,765
+AudioSynthWaveform       wav7; //xy=503,802
+AudioSynthWaveform       wav8; //xy=507,840
+AudioInputUSBOct         usb_oct_in;       //xy=524,931
+AudioMixer4              mixer1;         //xy=728,896
+AudioMixer4              mixer2; //xy=733,968
+AudioMixer4              mixer3; //xy=870,946
+AudioOutputI2S           i2sOut;           //xy=939,684
+AudioOutputUSBOct        usb_oct_out;       //xy=942,589
+
+AudioConnection          patchCord1(wav1, 0, usb_oct_out, 0);
+AudioConnection          patchCord2(wav1, 0, i2sOut, 0);
+AudioConnection          patchCord3(wav2, 0, usb_oct_out, 1);
+AudioConnection          patchCord4(wav3, 0, usb_oct_out, 2);
+AudioConnection          patchCord5(wav4, 0, usb_oct_out, 3);
+AudioConnection          patchCord6(wav5, 0, usb_oct_out, 4);
+AudioConnection          patchCord7(wav6, 0, usb_oct_out, 5);
+AudioConnection          patchCord8(wav7, 0, usb_oct_out, 6);
+AudioConnection          patchCord9(wav8, 0, usb_oct_out, 7);
+AudioConnection          patchCord10(usb_oct_in, 0, mixer1, 0);
+AudioConnection          patchCord11(usb_oct_in, 1, mixer1, 1);
+AudioConnection          patchCord12(usb_oct_in, 2, mixer1, 2);
+AudioConnection          patchCord13(usb_oct_in, 3, mixer1, 3);
+AudioConnection          patchCord14(usb_oct_in, 4, mixer2, 0);
+AudioConnection          patchCord15(usb_oct_in, 5, mixer2, 1);
+AudioConnection          patchCord16(usb_oct_in, 6, mixer2, 2);
+AudioConnection          patchCord17(usb_oct_in, 7, mixer2, 3);
+AudioConnection          patchCord18(mixer1, 0, mixer3, 0);
+AudioConnection          patchCord19(mixer2, 0, mixer3, 1);
+AudioConnection          patchCord20(mixer3, 0, i2sOut, 1);
+
+AudioControlSGTL5000     sgtl5000;     //xy=946,745
+// GUItool: end automatically generated code
+
+
+
+AudioSynthWaveform* wavs[] = {
+  &wav1,
+  &wav2,
+  &wav3,
+  &wav4,
+  &wav5,
+  &wav6,
+  &wav7,
+  &wav8
+};
+
+AudioMixer4* mixers[] = {&mixer1,&mixer2};
+
+uint32_t ledOff;
+
+void setup() 
+{
+  pinMode(LED_BUILTIN,OUTPUT);
+
+  // OK with 128 or 256 sample blocks, not working with 16 samples (yet)
+  AudioMemory(150 * 128 / AUDIO_BLOCK_SAMPLES); // empirical calculation!
+
+  while (!Serial)
+    ;
+
+  if (CrashReport)
+    Serial.print(CrashReport);
+  
+  sgtl5000.setAddress(HIGH);
+  sgtl5000.enable();
+  sgtl5000.volume(0.05f);
+
+  for (int i=0;i<8;i++)
+  {
+    wavs[i]->begin(0.5f,220.0f + 110.0f*i,WAVEFORM_TRIANGLE);
+    wavs[i]->phase(15.0f*i);
+  }
+
+  for (int i=0;i<2;i++)
+  {
+    for (int j=0;j<4;j++)
+      mixers[i]->gain(j,0.25f);
+  }
+
+  Serial.printf("Audio block size %d samples; sample rate %.2f; %d channels\n",AUDIO_BLOCK_SAMPLES,AUDIO_SAMPLE_RATE_EXACT,AUDIO_CHANNELS);
+  Serial.println("Running");
+}
+
+uint32_t lastBlocks;
+void loop() 
+{
+  if (millis() > ledOff)
+  {
+    digitalWrite(LED_BUILTIN,0);  
+  }
+
+  if (millis() - lastBlocks > 500)
+  {
+    lastBlocks = millis();
+    Serial.printf("Blocks %d; max %d\n",AudioMemoryUsage(),AudioMemoryUsageMax());
+    AudioMemoryUsageMaxReset();
+  }
+}


### PR DESCRIPTION
- Adds ability to pick USB channel count and audio engine sample rate and block size from Tools menu
- Adds objects with correct connection count to Design Tool
- Example testbed sketch
- Compiles even when 8ch / 96kHz is selected, though USB 1.1 might well misbehave- 
