### PR TITLE
Fix audiorateI build flag for teensy40 (typo: teensy41 → teensy40)

### DIFF
--- a/changedConfigfiles/boards.local.txt
+++ b/changedConfigfiles/boards.local.txt
@@ -13,13 +13,13 @@ teensy41.menu.audiorate.96.build.flags.audiorate=96000.0f
 teensy41.menu.audiorate.96.build.flags.audiorateI=96000
 teensy40.menu.audiorate.44=44.1kHz
 teensy40.menu.audiorate.44.build.flags.audiorate=44100.0f
-teensy41.menu.audiorate.44.build.flags.audiorateI=44100
+teensy40.menu.audiorate.44.build.flags.audiorateI=44100
 teensy40.menu.audiorate.48=48kHz
 teensy40.menu.audiorate.48.build.flags.audiorate=48000.0f
-teensy41.menu.audiorate.48.build.flags.audiorateI=48000
+teensy40.menu.audiorate.48.build.flags.audiorateI=48000
 teensy40.menu.audiorate.96=96kHz
 teensy40.menu.audiorate.96.build.flags.audiorate=96000.0f
-teensy41.menu.audiorate.96.build.flags.audiorateI=96000
+teensy40.menu.audiorate.96.build.flags.audiorateI=96000
 
 menu.audioblocksize=Audio block size
 teensy41.menu.audioblocksize.normal=128 samples (normal)


### PR DESCRIPTION
## Summary

In `changedConfigfiles/boards.local.txt`, three lines for the `audiorate` menu under `teensy40` were incorrectly written with the `teensy41` prefix, causing the `build.flags.audiorateI` flag to not be set when building for Teensy 4.0.

## Bug

The defective lines were 16, 19, and 22 in `changedConfigfiles/boards.local.txt`:

```
teensy40.menu.audiorate.44=44.1kHz
teensy40.menu.audiorate.44.build.flags.audiorate=44100.0f
teensy41.menu.audiorate.44.build.flags.audiorateI=44100      ← should be teensy40
teensy40.menu.audiorate.48=48kHz
teensy40.menu.audiorate.48.build.flags.audiorate=48000.0f
teensy41.menu.audiorate.48.build.flags.audiorateI=48000      ← should be teensy40
teensy40.menu.audiorate.96=96kHz
teensy40.menu.audiorate.96.build.flags.audiorate=96000.0f
teensy41.menu.audiorate.96.build.flags.audiorateI=96000      ← should be teensy40
```

## Impact

When building for Teensy 4.0 with any non-default `audiorate`:

- `AUDIO_SAMPLE_RATE_EXACT` is set correctly from the menu (`teensy40` line)
- `AUDIO_SAMPLE_RATE_I` falls back to the `platform.txt` default `44100` because the `teensy40`-prefixed line is missing

In `usb_desc.h` this propagates into:

```c
MAX_SAMPLES_PER_MS = CEIL_DIV(AUDIO_SAMPLE_RATE_I, MS_PER_SEC)
BANDWIDTH_BYTES_PER_MSEC_480 = MAX_SAMPLES_PER_MS * AUDIO_SUBSLOT_SIZE * USB_AUDIO_NO_CHANNELS_480
AUDIO_RX_TX_SIZE_SAMPLES_480 = CEIL_DIV(AUDIO_SAMPLE_RATE_I, AUDIO_NUM_FRAMES_PER_SEC_480) + RX_TX_ADD_SAMPLES
```

So USB endpoint buffers and bandwidth calculations are sized for 44.1 kHz while the actual audio stream (via `AUDIO_SAMPLE_RATE_EXACT`) is at the selected rate (e.g. 48 kHz). On a 4-channel × 32-bit configuration this caused continuous USB buffer overruns and produced WAV files roughly 3.66× shorter than the real recording duration (observed in production firmware for a PCM1841 4-mic TDM project on Teensy 4.0 with `AUDIO_SUBSLOT_SIZE=4`).

This bug is invisible on Teensy 4.1 because the equivalent lines for `teensy41` are correct. It only affects Teensy 4.0 users, which probably explains why it went undetected — most contributors here appear to use Teensy 4.1.

## Fix

Three single-line changes: `teensy41` → `teensy40` in the lines marked above. No other changes.

## Verification

Tested on Teensy 4.0 + Teensyduino 1.60.0 + alex6679 main (commit `8b81d52`) + 4-channel USB Audio at 48 kHz:

- **Before fix:** 10 s real recording → ~2.73 s in WAV (3.66× too short)
- **After fix:** 10 s real recording → ~10 s in WAV (correct)